### PR TITLE
fix(encoding) Fixes frame timing

### DIFF
--- a/.versioning/changes/cB63FxBNOb.minor.md
+++ b/.versioning/changes/cB63FxBNOb.minor.md
@@ -1,0 +1,2 @@
+Fixes some timing issues that were causing audio / video desync.
+Fixes `mp4` output containers.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ctrl+C / SIGINT will stop the capture session and finalize the output media.
 ### Help. I'm getting the following error
 
 #### `ERROR: Couldn't create NvFBC instance`
-*Shadow Cast* uses the *NvFBC* facility to provide efficient, low-latency framebuffer capture. By default, nvidia disables this on most (if not all) of its commercial GPUs. However, there are two ways around this restriction...
+*Shadow Cast* uses the *NvFBC* facility to provide efficient, low-latency framebuffer capture. By default, nvidia disables this on most (if not all) of its consumer-level GPUs. However, there are two ways around this restriction...
 
 - You can find a utility to patch your nvidia drivers in the [keylase/nvidia-patch](https://github.com/keylase/nvidia-patch) GitHub repo.
 - You can obtain a "key" to unlock this feature at runtime. You can then set the `SHADOW_CAST_NVFBC_KEY` environment variable to the base64 encoded value of this key prior to invoking `shadow-cast`. Unfortunately, due to the uncertainty around the legalities of this method, I'm unable to provide this key in this project's source.

--- a/src/av/codec.cpp
+++ b/src/av/codec.cpp
@@ -91,10 +91,8 @@ auto create_video_encoder(std::string const& encoder_name,
     if (auto const ret = avcodec_open2(
             video_encoder_context.get(), video_encoder.get(), &options);
         ret < 0) {
-        throw CodecError
-        {
-            "Failed to open video codec: " + av_error_to_string(ret)
-        };
+        throw CodecError { "Failed to open video codec: " +
+                           av_error_to_string(ret) };
     }
 
     return video_encoder_context;

--- a/src/av/media_chunk.cpp
+++ b/src/av/media_chunk.cpp
@@ -5,8 +5,8 @@ namespace sc
 {
 auto DynamicBuffer::prepare(std::size_t n) -> std::span<std::uint8_t>
 {
-    if (n > size())
-        data_.resize(n - size());
+    if (n > capacity())
+        data_.resize(data_.size() + (n - capacity()));
 
     return std::span { next(begin(data_), bytes_committed_), end(data_) };
 }
@@ -38,6 +38,11 @@ auto DynamicBuffer::data() const noexcept -> std::span<std::uint8_t const>
 auto DynamicBuffer::size() const noexcept -> std::size_t
 {
     return bytes_committed_;
+}
+
+auto DynamicBuffer::capacity() const noexcept -> std::size_t
+{
+    return data_.size() - size();
 }
 
 auto MediaChunk::channel_buffers() noexcept -> std::vector<DynamicBuffer>&

--- a/src/av/media_chunk.hpp
+++ b/src/av/media_chunk.hpp
@@ -16,6 +16,7 @@ struct DynamicBuffer
     auto data() noexcept -> std::span<std::uint8_t>;
     auto data() const noexcept -> std::span<std::uint8_t const>;
     auto size() const noexcept -> std::size_t;
+    auto capacity() const noexcept -> std::size_t;
 
 private:
     std::vector<std::uint8_t> data_;

--- a/src/handlers/audio_chunk_writer.hpp
+++ b/src/handlers/audio_chunk_writer.hpp
@@ -13,19 +13,21 @@ struct ChunkWriter
                          AVCodecContext* codec_context,
                          AVStream* stream) noexcept;
 
-    auto operator()(sc::MediaChunk chunk) -> void;
+    auto operator()(MediaChunk chunk) -> void;
 
 private:
-    sc::BorrowedPtr<AVFormatContext> format_context_;
-    sc::BorrowedPtr<AVCodecContext> codec_context_;
-    sc::BorrowedPtr<AVStream> stream_;
-    sc::FramePtr frame_;
+    BorrowedPtr<AVFormatContext> format_context_;
+    BorrowedPtr<AVCodecContext> codec_context_;
+    BorrowedPtr<AVStream> stream_;
+    FramePtr frame_;
+    std::size_t total_samples_written_ { 0 };
+    MediaChunk buffer_;
 };
 
 auto send_frame(AVFrame* frame,
                 AVCodecContext* ctx,
                 AVFormatContext* fmt,
-                int stream_index) -> void;
+                AVStream* stream) -> void;
 
 } // namespace sc
 

--- a/src/handlers/stream_finalizer.cpp
+++ b/src/handlers/stream_finalizer.cpp
@@ -9,10 +9,14 @@ namespace sc
 StreamFinalizer::StreamFinalizer(
     BorrowedPtr<AVFormatContext> format_context,
     BorrowedPtr<AVCodecContext> audio_codec_context,
-    BorrowedPtr<AVCodecContext> video_codec_context)
+    BorrowedPtr<AVCodecContext> video_codec_context,
+    BorrowedPtr<AVStream> audio_stream,
+    BorrowedPtr<AVStream> video_stream)
     : format_context_ { format_context }
     , audio_codec_context_ { audio_codec_context }
     , video_codec_context_ { video_codec_context }
+    , audio_stream_ { audio_stream }
+    , video_stream_ { video_stream }
 {
 }
 
@@ -20,13 +24,17 @@ auto StreamFinalizer::operator()() const -> void
 {
     /* Send a end marker to the audio stream...
      */
-    sc::send_frame(
-        nullptr, audio_codec_context_.get(), format_context_.get(), 0);
+    sc::send_frame(nullptr,
+                   audio_codec_context_.get(),
+                   format_context_.get(),
+                   audio_stream_.get());
 
     /* Hijack this handler to send an end marker to the video stream, too...
      */
-    sc::send_frame(
-        nullptr, video_codec_context_.get(), format_context_.get(), 1);
+    sc::send_frame(nullptr,
+                   video_codec_context_.get(),
+                   format_context_.get(),
+                   video_stream_.get());
 
     if (auto const ret = av_write_trailer(format_context_.get()); ret < 0)
         throw std::runtime_error { "Failed to write trailer: " +

--- a/src/handlers/stream_finalizer.hpp
+++ b/src/handlers/stream_finalizer.hpp
@@ -11,7 +11,9 @@ struct StreamFinalizer
 {
     StreamFinalizer(BorrowedPtr<AVFormatContext> format_context,
                     BorrowedPtr<AVCodecContext> audio_codec_context,
-                    BorrowedPtr<AVCodecContext> video_codec_context);
+                    BorrowedPtr<AVCodecContext> video_codec_context,
+                    BorrowedPtr<AVStream> audio_stream,
+                    BorrowedPtr<AVStream> video_stream);
 
     auto operator()() const -> void;
 
@@ -19,6 +21,8 @@ private:
     BorrowedPtr<AVFormatContext> format_context_;
     BorrowedPtr<AVCodecContext> audio_codec_context_;
     BorrowedPtr<AVCodecContext> video_codec_context_;
+    BorrowedPtr<AVStream> audio_stream_;
+    BorrowedPtr<AVStream> video_stream_;
 };
 
 } // namespace sc

--- a/src/handlers/video_frame_writer.cpp
+++ b/src/handlers/video_frame_writer.cpp
@@ -7,9 +7,11 @@ namespace sc
 {
 
 VideoFrameWriter::VideoFrameWriter(AVFormatContext* fmt_context,
-                                   AVCodecContext* codec_context)
+                                   AVCodecContext* codec_context,
+                                   AVStream* stream)
     : format_context_ { fmt_context }
     , codec_context_ { codec_context }
+    , stream_ { stream }
     , frame_ { av_frame_alloc() }
 {
 }
@@ -46,10 +48,12 @@ auto VideoFrameWriter::operator()(CUdeviceptr cu_device_ptr,
     frame_->colorspace = codec_context_->colorspace;
     frame_->chroma_location = codec_context_->chroma_sample_location;
 
-    frame_->pts = sc::global_elapsed.value();
+    frame_->pts = frame_number_++;
 
-    sc::send_frame(
-        frame_.get(), codec_context_.get(), format_context_.get(), 1);
+    sc::send_frame(frame_.get(),
+                   codec_context_.get(),
+                   format_context_.get(),
+                   stream_.get());
 }
 
 } // namespace sc

--- a/src/handlers/video_frame_writer.hpp
+++ b/src/handlers/video_frame_writer.hpp
@@ -9,14 +9,17 @@ namespace sc
 struct VideoFrameWriter
 {
     VideoFrameWriter(AVFormatContext* fmt_context,
-                     AVCodecContext* codec_context);
+                     AVCodecContext* codec_context,
+                     AVStream* stream);
 
     auto operator()(CUdeviceptr cu_device_ptr, NVFBC_FRAME_GRAB_INFO) -> void;
 
 private:
     sc::BorrowedPtr<AVFormatContext> format_context_;
     sc::BorrowedPtr<AVCodecContext> codec_context_;
+    sc::BorrowedPtr<AVStream> stream_;
     sc::FramePtr frame_;
+    std::size_t frame_number_ { 0 };
 };
 
 } // namespace sc

--- a/src/utils/elapsed.cpp
+++ b/src/utils/elapsed.cpp
@@ -12,4 +12,13 @@ auto Elapsed::value() const noexcept -> std::uint64_t
     return ch::duration_cast<ch::milliseconds>(now - start_).count();
 }
 
+auto Elapsed::nanosecond_value() const noexcept -> std::uint64_t
+{
+    namespace ch = std::chrono;
+
+    auto const now = ch::steady_clock::now();
+
+    return ch::duration_cast<ch::nanoseconds>(now - start_).count();
+}
+
 } // namespace sc

--- a/src/utils/elapsed.hpp
+++ b/src/utils/elapsed.hpp
@@ -10,6 +10,7 @@ namespace sc
 struct Elapsed
 {
     auto value() const noexcept -> std::uint64_t;
+    auto nanosecond_value() const noexcept -> std::uint64_t;
 
 private:
     std::chrono::time_point<std::chrono::steady_clock> start_ =


### PR DESCRIPTION
- Uses a a better time base for input frames; Frames per second for video and samples per second for audio.
- Correctly rescales the timestamp (pts/dts) values to the output streams' time base.
- Tightens up the video frame sampling rate by using nanoseconds for the internal frame time values.

Fixes #2 