### PR TITLE
feat(audio) Uses memory pool for audio data to reduce allocations

### DIFF
--- a/.versioning/changes/hteiljos7O.minor.md
+++ b/.versioning/changes/hteiljos7O.minor.md
@@ -1,0 +1,1 @@
+Performance improvement to audio capture by using a memory pool to reduce allocations

--- a/src/av/media_chunk.cpp
+++ b/src/av/media_chunk.cpp
@@ -3,6 +3,8 @@
 
 namespace sc
 {
+auto DynamicBuffer::reset() noexcept -> void { bytes_committed_ = 0; }
+
 auto DynamicBuffer::prepare(std::size_t n) -> std::span<std::uint8_t>
 {
     if (n > capacity())
@@ -43,6 +45,14 @@ auto DynamicBuffer::size() const noexcept -> std::size_t
 auto DynamicBuffer::capacity() const noexcept -> std::size_t
 {
     return data_.size() - size();
+}
+
+auto MediaChunk::reset() noexcept -> void
+{
+    timestamp_ms = 0;
+    sample_count = 0;
+    for (auto& b : channel_buffers())
+        b.reset();
 }
 
 auto MediaChunk::channel_buffers() noexcept -> std::vector<DynamicBuffer>&

--- a/src/av/media_chunk.hpp
+++ b/src/av/media_chunk.hpp
@@ -6,6 +6,8 @@
 #include <span>
 #include <vector>
 
+#include "utils/intrusive_list.hpp"
+
 namespace sc
 {
 struct DynamicBuffer
@@ -17,18 +19,20 @@ struct DynamicBuffer
     auto data() const noexcept -> std::span<std::uint8_t const>;
     auto size() const noexcept -> std::size_t;
     auto capacity() const noexcept -> std::size_t;
+    auto reset() noexcept -> void;
 
 private:
     std::vector<std::uint8_t> data_;
     std::size_t bytes_committed_ { 0 };
 };
 
-struct MediaChunk
+struct MediaChunk : ListItemBase
 {
     std::size_t timestamp_ms { 0 };
     std::size_t sample_count { 0 };
     auto channel_buffers() noexcept -> std::vector<DynamicBuffer>&;
     auto channel_buffers() const noexcept -> std::vector<DynamicBuffer> const&;
+    auto reset() noexcept -> void;
 
 private:
     std::vector<DynamicBuffer> buffers_;

--- a/src/handlers/audio_chunk_writer.cpp
+++ b/src/handlers/audio_chunk_writer.cpp
@@ -1,38 +1,9 @@
 #include "handlers/audio_chunk_writer.hpp"
 #include "av/sample_format.hpp"
 #include <algorithm>
+#include <cassert>
 #include <memory>
 #include <numeric>
-
-namespace
-{
-
-auto append_chunk(sc::MediaChunk const& source, sc::MediaChunk& dest) -> void
-{
-    dest.sample_count += source.sample_count;
-    auto channels_required =
-        std::max(0,
-                 static_cast<int>(source.channel_buffers().size() -
-                                  dest.channel_buffers().size()));
-
-    while (channels_required--)
-        dest.channel_buffers().push_back(sc::DynamicBuffer {});
-
-    auto it = source.channel_buffers().begin();
-    auto out_it = dest.channel_buffers().begin();
-
-    for (; it != source.channel_buffers().end(); ++it) {
-        auto& src_buf = *it;
-        auto& dst_buf = *out_it++;
-
-        auto dst_data = dst_buf.prepare(src_buf.size());
-        std::copy(
-            src_buf.data().begin(), src_buf.data().end(), dst_data.begin());
-        dst_buf.commit(dst_data.size());
-    }
-}
-
-} // namespace
 
 namespace sc
 {
@@ -83,71 +54,47 @@ ChunkWriter::ChunkWriter(AVFormatContext* format_context,
 {
 }
 
-auto ChunkWriter::operator()(MediaChunk chnk) -> void
+auto ChunkWriter::operator()(MediaChunk const& chunk) -> void
 {
-    /* Append this chunk to our buffered data...
-     */
-    append_chunk(chnk, buffer_);
-
+    assert(static_cast<int>(chunk.sample_count) == codec_context_->frame_size);
     sc::SampleFormat const sample_format =
         sc::convert_from_libav_format(codec_context_->sample_fmt);
 
     auto const sample_size = sc::sample_format_size(sample_format);
     auto const interleaved = sc::is_interleaved_format(sample_format);
 
-    auto samples_remaining = buffer_.sample_count;
+    sc::BorrowedPtr<AVFrame> frame = frame_.get();
 
-    while (samples_remaining) {
-        sc::BorrowedPtr<AVFrame> frame = frame_.get();
+    frame->nb_samples = chunk.sample_count;
+    frame->format = codec_context_->sample_fmt;
+    frame->sample_rate = codec_context_->sample_rate;
+    frame->channels = interleaved ? 2 : chunk.channel_buffers().size();
 
-        /* We need to ensure we fill an output frame completely, otherwise
-         * the audio/video sync will be off. If we don't have enough samples
-         * then we just don't emit a frame and wait until then next
-         * time we're called and check again...
-         */
-        if (static_cast<int>(samples_remaining) < codec_context_->frame_size)
-            break;
+    frame->channel_layout = AV_CH_LAYOUT_STEREO;
+    frame->pts = total_samples_written_;
+    total_samples_written_ += frame->nb_samples;
 
-        frame->nb_samples = codec_context_->frame_size
-                                ? std::min(codec_context_->frame_size,
-                                           static_cast<int>(samples_remaining))
-                                : samples_remaining;
+    sc::initialize_writable_buffer(frame.get());
 
-        frame->format = codec_context_->sample_fmt;
-        frame->sample_rate = codec_context_->sample_rate;
-        frame->channels = interleaved ? 2 : buffer_.channel_buffers().size();
+    AVFrameUnrefGuard unref_guard { frame };
 
-        frame->channel_layout = AV_CH_LAYOUT_STEREO;
-        frame->pts = total_samples_written_;
-        total_samples_written_ += frame->nb_samples;
+    auto n = 0;
+    for (auto const& channel_buffer : chunk.channel_buffers()) {
+        std::size_t const num_bytes = interleaved
+                                          ? frame->nb_samples * sample_size * 2
+                                          : frame->nb_samples * sample_size;
 
-        sc::initialize_writable_buffer(frame.get());
+        std::span source = channel_buffer.data().subspan(0, num_bytes);
+        std::span target { reinterpret_cast<std::uint8_t*>(frame->data[n++]),
+                           num_bytes };
 
-        AVFrameUnrefGuard unref_guard { frame };
-
-        auto n = 0;
-        for (auto& channel_buffer : buffer_.channel_buffers()) {
-            std::size_t const num_bytes =
-                interleaved ? frame->nb_samples * sample_size * 2
-                            : frame->nb_samples * sample_size;
-
-            std::span source = channel_buffer.data().subspan(0, num_bytes);
-            std::span target {
-                reinterpret_cast<std::uint8_t*>(frame->data[n++]), num_bytes
-            };
-
-            std::copy(begin(source), end(source), begin(target));
-            channel_buffer.consume(num_bytes);
-        }
-
-        samples_remaining -= frame->nb_samples;
-        buffer_.sample_count -= frame->nb_samples;
-
-        send_frame(frame.get(),
-                   codec_context_.get(),
-                   format_context_.get(),
-                   stream_.get());
+        std::copy(begin(source), end(source), begin(target));
     }
+
+    send_frame(frame.get(),
+               codec_context_.get(),
+               format_context_.get(),
+               stream_.get());
 }
 
 } // namespace sc

--- a/src/handlers/audio_chunk_writer.hpp
+++ b/src/handlers/audio_chunk_writer.hpp
@@ -13,7 +13,7 @@ struct ChunkWriter
                          AVCodecContext* codec_context,
                          AVStream* stream) noexcept;
 
-    auto operator()(MediaChunk chunk) -> void;
+    auto operator()(MediaChunk const& chunk) -> void;
 
 private:
     BorrowedPtr<AVFormatContext> format_context_;
@@ -21,7 +21,6 @@ private:
     BorrowedPtr<AVStream> stream_;
     FramePtr frame_;
     std::size_t total_samples_written_ { 0 };
-    MediaChunk buffer_;
 };
 
 auto send_frame(AVFrame* frame,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,8 +178,10 @@ auto run(int argc, char** argv) -> void
 
     sc::Context ctx;
     ctx.services().add_from_factory<sc::AudioService>([&] {
-        return std::make_unique<sc::AudioService>(supported_formats.front(),
-                                                  48'000);
+        return std::make_unique<sc::AudioService>(
+            supported_formats.front(),
+            48'000,
+            audio_encoder_context->frame_size);
     });
 
     ctx.services().add_from_factory<sc::VideoService>([&] {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -5,7 +5,9 @@
 #include "./utils/borrowed_ptr.hpp"
 #include "./utils/cmd_line.hpp"
 #include "./utils/elapsed.hpp"
+#include "./utils/intrusive_list.hpp"
 #include "./utils/non_pointer.hpp"
+#include "./utils/pool.hpp"
 #include "./utils/receiver.hpp"
 #include "./utils/result.hpp"
 

--- a/src/utils/intrusive_list.hpp
+++ b/src/utils/intrusive_list.hpp
@@ -1,0 +1,290 @@
+#ifndef SHADOW_CAST_UTILS_INTRUSIVE_LIST_HPP_INCLUDED
+#define SHADOW_CAST_UTILS_INTRUSIVE_LIST_HPP_INCLUDED
+
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+namespace sc
+{
+
+struct ListItemBase
+{
+    ListItemBase* prev { nullptr };
+    ListItemBase* next { nullptr };
+};
+
+template <typename T>
+concept ListItem = std::is_convertible_v<T&, ListItemBase const&>;
+
+template <ListItem T>
+struct IntrusiveList
+{
+    IntrusiveList() noexcept { sentinel_.next = sentinel_.prev = &sentinel_; }
+
+    /* Not copyable; We don't know how to allocate
+     * or copy items...
+     */
+    IntrusiveList(IntrusiveList const&) = delete;
+    auto operator=(IntrusiveList const&) -> IntrusiveList& = delete;
+
+    IntrusiveList(IntrusiveList&& other) noexcept
+    {
+        if (other.empty()) {
+            sentinel_.next = sentinel_.prev = &sentinel_;
+        }
+        else {
+            other.sentinel_.next->prev = &sentinel_;
+            other.sentinel_.prev->next = &sentinel_;
+
+            other.sentinel_.next = other.sentinel_.prev = &other.sentinel_;
+        }
+    }
+
+    auto operator=(IntrusiveList&& other) noexcept -> IntrusiveList&
+    {
+        if (this == &other)
+            return *this;
+
+        using std::swap;
+        auto tmp { std::move(other) };
+        swap(*this, tmp);
+        return *this;
+    }
+
+    template <bool IsConst>
+    struct Iterator
+    {
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::conditional_t<IsConst,
+                                              std::remove_const_t<T> const,
+                                              std::remove_const_t<T>>;
+        using pointer = value_type*;
+        using reference = value_type&;
+        using const_reference = std::remove_const_t<value_type> const&;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+        using Element =
+            std::conditional_t<IsConst, ListItemBase const, ListItemBase>;
+
+        Element* current;
+
+        Iterator(ListItemBase* item) noexcept
+            : current { item }
+        {
+        }
+
+        Iterator(Iterator<false> const& other) noexcept
+        requires(IsConst)
+            : current { other.current }
+        {
+        }
+
+        Iterator(Iterator const& other) noexcept
+            : current { other.current }
+        {
+        }
+
+        auto operator=(Iterator const& other) noexcept -> Iterator&
+        {
+            current = other.current;
+            return *this;
+        }
+
+        auto operator=(Iterator<false> const& other) noexcept -> Iterator&
+        requires(IsConst)
+        {
+            current = other.current;
+            return *this;
+        }
+
+        [[nodiscard]] auto operator->() const noexcept -> pointer
+        {
+            return static_cast<value_type*>(current);
+        }
+
+        [[nodiscard]] auto operator*() noexcept -> reference
+        requires(!IsConst)
+        {
+            return *static_cast<value_type*>(current);
+        }
+
+        [[nodiscard]] auto operator*() const noexcept -> const_reference
+        {
+            return *static_cast<std::remove_const_t<value_type> const*>(
+                current);
+        }
+
+        auto operator++(int) noexcept -> Iterator
+        {
+            auto tmp { *this };
+            operator++();
+            return tmp;
+        }
+
+        auto operator++() noexcept -> Iterator&
+        {
+            current = current->next;
+            return *this;
+        }
+
+        auto operator--(int) noexcept -> Iterator
+        {
+            auto tmp { *this };
+            operator--();
+            return tmp;
+        }
+
+        auto operator--() noexcept -> Iterator&
+        {
+            current = current->prev;
+            return *this;
+        }
+
+        [[nodiscard]] auto operator==(Iterator const& other) const noexcept
+            -> bool
+        {
+            return current == other.current;
+        }
+
+        [[nodiscard]] auto operator!=(Iterator const& other) const noexcept
+            -> bool
+        {
+            return !(*this == other);
+        }
+    };
+
+    using iterator = Iterator<false>;
+    using const_iterator = Iterator<true>;
+
+    [[nodiscard]] auto empty() const noexcept -> bool
+    {
+        return sentinel_.next == &sentinel_;
+    }
+
+    [[nodiscard]] auto erase(iterator pos) noexcept -> iterator
+    {
+        assert(pos != end());
+        auto* item = &*pos;
+        auto next_item = std::next(pos);
+
+        item->next->prev = item->prev;
+        item->prev->next = item->next;
+
+        return next_item;
+    }
+
+    [[nodiscard]] auto front() noexcept -> typename iterator::reference
+    {
+        assert(!empty());
+        return *begin();
+    }
+
+    [[nodiscard]] auto front() const noexcept ->
+        typename const_iterator::reference
+    {
+        assert(!empty());
+        return *begin();
+    }
+
+    [[nodiscard]] auto back() noexcept -> typename iterator::reference
+    {
+        assert(!empty());
+        return *std::next(end(), -1);
+    }
+
+    [[nodiscard]] auto back() const noexcept ->
+        typename const_iterator::reference
+    {
+        assert(!empty());
+        return *std::next(end(), -1);
+    }
+
+    auto push_front(T* item) noexcept -> void
+    {
+        assert(item);
+        sentinel_.next->prev = item;
+        item->prev = &sentinel_;
+        item->next = sentinel_.next;
+        sentinel_.next = item;
+    }
+
+    auto push_back(T* item) noexcept -> void
+    {
+        assert(item);
+        sentinel_.prev->next = item;
+        item->next = &sentinel_;
+        item->prev = sentinel_.prev;
+        sentinel_.prev = item;
+    }
+
+    auto pop_back() noexcept -> void
+    {
+        assert(!empty());
+
+        auto* item_to_remove = sentinel_.prev;
+
+        sentinel_.prev = item_to_remove->prev;
+        sentinel_.prev->next = &sentinel_;
+    }
+
+    auto pop_front() noexcept -> void
+    {
+        assert(!empty());
+
+        auto* item_to_remove = sentinel_.next;
+        sentinel_.next = item_to_remove->next;
+        sentinel_.next->prev = &sentinel_;
+    }
+
+    [[nodiscard]] auto insert(T* item, iterator before) -> iterator
+    {
+        auto* before_item = before.current;
+        before_item->prev->next = item;
+        item->prev = before_item->prev;
+        item->next = before_item;
+        before_item->prev = item;
+        return before;
+    }
+
+    auto
+    splice(iterator before, IntrusiveList& other, iterator first, iterator last)
+        -> void
+    {
+        auto it = first;
+        while (it != last) {
+            auto* val = &*it;
+            it = other.erase(it);
+            before = insert(val, before);
+        }
+    }
+
+    auto splice(iterator before, IntrusiveList& other) -> void
+    {
+        splice(before, other, other.begin(), other.end());
+    }
+
+    [[nodiscard]] auto begin() noexcept -> iterator
+    {
+        return iterator { sentinel_.next };
+    }
+    [[nodiscard]] auto begin() const noexcept -> const_iterator
+    {
+        return const_iterator { sentinel_.next };
+    }
+
+    [[nodiscard]] auto end() noexcept -> iterator
+    {
+        return iterator { &sentinel_ };
+    }
+    [[nodiscard]] auto end() const noexcept -> const_iterator
+    {
+        return const_iterator { &sentinel_ };
+    }
+
+private:
+    ListItemBase sentinel_;
+};
+} // namespace sc
+#endif // SHADOW_CAST_UTILS_INTRUSIVE_LIST_HPP_INCLUDED

--- a/src/utils/pool.hpp
+++ b/src/utils/pool.hpp
@@ -1,0 +1,173 @@
+#ifndef SHADOW_CAST_UTILS_POOL_HPP_INCLUDED
+#define SHADOW_CAST_UTILS_POOL_HPP_INCLUDED
+
+#include "utils/intrusive_list.hpp"
+#include <memory>
+#include <mutex>
+
+namespace sc
+{
+
+// clang-format off
+template<typename T>
+concept PoolItem = ListItem<T> && requires(T val) {
+    { val.reset() };
+};
+// clang-format on
+
+struct DefaultPoolSynchronization
+{
+    auto enter() noexcept -> void {}
+    auto leave() noexcept -> void {}
+};
+
+struct MutexPoolSynchronization
+{
+    auto enter() noexcept -> void { mutex_.lock(); }
+    auto leave() noexcept -> void { mutex_.unlock(); }
+
+private:
+    std::mutex mutex_;
+};
+
+template <typename T>
+struct SynchronizationGuard
+{
+    T& sync;
+
+    SynchronizationGuard(T& s) noexcept
+        : sync { s }
+    {
+        sync.enter();
+    }
+
+    ~SynchronizationGuard() { sync.leave(); }
+
+    SynchronizationGuard(SynchronizationGuard const&) = delete;
+    SynchronizationGuard(SynchronizationGuard&&) = delete;
+    auto operator=(SynchronizationGuard const&)
+        -> SynchronizationGuard& = delete;
+    auto operator=(SynchronizationGuard&&) -> SynchronizationGuard& = delete;
+};
+
+template <ListItem T,
+          typename Allocator = std::allocator<T>,
+          typename Synchronization = DefaultPoolSynchronization>
+struct Pool
+{
+    struct PoolItemDeleter
+    {
+        PoolItemDeleter(Pool<T, Allocator, Synchronization>& pool) noexcept
+            : pool_ { &pool }
+        {
+        }
+
+        auto operator()(T* ptr) const noexcept -> void { pool_->put(ptr); }
+
+    private:
+        Pool<T, Allocator, Synchronization>* pool_;
+    };
+
+    using ItemPtr = std::unique_ptr<T, PoolItemDeleter>;
+
+    explicit Pool(Allocator alloc = Allocator {}) noexcept
+        : alloc_ { alloc }
+    {
+    }
+
+    Pool(Pool const&) = delete;
+    auto operator=(Pool const&) -> Pool& = delete;
+
+    Pool(Pool&&) noexcept = default;
+    auto operator=(Pool&&) -> Pool& = default;
+
+    ~Pool() { clear(); }
+
+    /* Returns an item from the pool, or allocates
+     * a new item if the pool is empty. The caller
+     * must not delete any items returned by this
+     * function. They must instead call put()
+     */
+    [[nodiscard]] auto get() -> ItemPtr
+    {
+        {
+            SynchronizationGuard guard { sync_ };
+            if (!pool_list_.empty()) {
+                auto it = pool_list_.begin();
+                T* item = &*it;
+                static_cast<void>(pool_list_.erase(it));
+                if constexpr (PoolItem<T>) {
+                    item->reset();
+                }
+                return ItemPtr { item, *this };
+            }
+        }
+
+        T* new_item = allocate_item();
+        try {
+            new (static_cast<void*>(new_item)) T {};
+        }
+        catch (...) {
+            deallocate_item(new_item);
+            throw;
+        }
+
+        return ItemPtr { new_item, *this };
+    }
+
+    /* Returns an item to the pool. The item
+     * must have been previously obtained from
+     * a call to get()
+     */
+    auto put(T* item) noexcept -> void
+    {
+        SynchronizationGuard guard { sync_ };
+        pool_list_.push_back(item);
+    }
+
+    /* Removes and deallocates all remaining
+     * items in the pool. There should have been a
+     * equal number of put() and get() calls
+     * before calling clear()
+     */
+    auto clear() noexcept -> void
+    {
+        SynchronizationGuard guard { sync_ };
+        auto it = pool_list_.begin();
+        while (it != pool_list_.end()) {
+            T* item = &*it;
+            it = pool_list_.erase(it);
+
+            item->~T();
+            deallocate_item(item);
+        }
+    }
+
+private:
+    auto allocate_item() -> T*
+    {
+        using RecastAlloc =
+            typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
+        RecastAlloc alloc { alloc_ };
+        return alloc.allocate(1);
+    }
+
+    auto deallocate_item(T* item) noexcept -> void
+    {
+        using RecastAlloc =
+            typename std::allocator_traits<Allocator>::template rebind_alloc<T>;
+        RecastAlloc alloc { alloc_ };
+        alloc.deallocate(item, 1);
+    }
+
+    Allocator alloc_;
+    IntrusiveList<T> pool_list_;
+    Synchronization sync_;
+};
+
+template <ListItem T, typename Allocator = std::allocator<T>>
+using SynchronizedPool = Pool<T, Allocator, MutexPoolSynchronization>;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_UTILS_POOL_HPP_INCLUDED

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 add_library(testing OBJECT testing.cpp)
 
 make_test(NAME base64_tests SOURCES base64_tests.cpp SIMPLE)
+make_test(NAME intrusive_list_tests SOURCES intrusive_list_tests.cpp SIMPLE)
+make_test(NAME pool_tests SOURCES pool_tests.cpp SIMPLE)
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/.private/nvfbc.key)
     file(STRINGS ${PROJECT_SOURCE_DIR}/.private/nvfbc.key SHADOW_CAST_NVFBC_KEY)

--- a/tests/intrusive_list_tests.cpp
+++ b/tests/intrusive_list_tests.cpp
@@ -1,0 +1,184 @@
+#include "testing.hpp"
+#include "utils/intrusive_list.hpp"
+
+struct Identity : sc::ListItemBase
+{
+    Identity() noexcept = default;
+
+    Identity(int v) noexcept
+        : value { v }
+    {
+    }
+
+    int value { 0 };
+};
+
+auto should_construct_empty() -> void
+{
+    sc::IntrusiveList<Identity> list;
+    EXPECT(list.empty());
+}
+
+auto should_add_item_and_not_be_empty() -> void
+{
+    Identity id;
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&id);
+    EXPECT(!list.empty());
+}
+
+auto should_remove_item() -> void
+{
+    Identity a, b;
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&a);
+    list.push_back(&b);
+
+    list.pop_back();
+    EXPECT(!list.empty());
+    list.pop_front();
+    EXPECT(list.empty());
+}
+
+auto should_iterate_through_non_empty_list() -> void
+{
+    Identity item_a { 1 }, item_b { 2 };
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&item_a);
+    list.push_front(&item_b);
+
+    decltype(item_a.value) sum {};
+    decltype(sum) const expected = 3;
+
+    for (auto const& i : list)
+        sum += i.value;
+
+    EXPECT(sum == expected);
+}
+
+auto should_add_in_correct_order() -> void
+{
+    Identity a { 1 }, b { 2 }, c { 3 };
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&b);
+    list.push_front(&a);
+    list.push_back(&c);
+
+    auto const& const_list = list;
+
+    auto it = const_list.begin();
+    EXPECT(it->value == 1);
+    it++;
+    EXPECT(it->value == 2);
+    it++;
+    EXPECT(it->value == 3);
+    it++;
+    EXPECT(it == list.end());
+}
+
+auto should_erase_items() -> void
+{
+    Identity a { 1 }, b { 2 }, c { 3 };
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&b);
+    list.push_front(&a);
+    list.push_back(&c);
+
+    auto it = list.begin();
+    EXPECT(it->value == 1);
+    it = list.erase(it);
+    EXPECT(it->value == 2);
+    it = list.erase(it);
+    EXPECT(it->value == 3);
+    it = list.erase(it);
+    EXPECT(it == list.end());
+}
+
+auto should_erase_and_insert() -> void
+{
+    Identity a;
+    sc::IntrusiveList<Identity> list;
+
+    for (auto i = 0; i < 10; ++i) {
+        list.push_back(&a);
+        auto it = list.erase(list.begin());
+        EXPECT(it == list.end());
+        EXPECT(list.empty());
+    }
+}
+
+auto should_iterate() -> void
+{
+    Identity a { 1 }, b { 2 }, c { 3 };
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&a);
+    list.push_back(&b);
+    list.push_back(&c);
+
+    EXPECT(std::distance(list.begin(), list.end()) == 3);
+
+    auto n = 0;
+    for ([[maybe_unused]] auto const& i : list)
+        ++n;
+
+    EXPECT(n == 3);
+}
+
+auto should_splice() -> void
+{
+    Identity a { 1 }, b { 2 }, c { 3 };
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&a);
+    list.push_back(&b);
+    list.push_back(&c);
+
+    sc::IntrusiveList<Identity> other_list;
+
+    other_list.splice(other_list.begin(), list);
+
+    EXPECT(!other_list.empty());
+    EXPECT(list.empty());
+
+    auto it = other_list.begin();
+    EXPECT((it++)->value == 1);
+    EXPECT((it++)->value == 2);
+    EXPECT((it++)->value == 3);
+    EXPECT(it == other_list.end());
+}
+
+auto should_splice_range() -> void
+{
+    Identity a { 1 }, b { 2 }, c { 3 };
+    sc::IntrusiveList<Identity> list;
+    list.push_back(&a);
+    list.push_back(&b);
+    list.push_back(&c);
+
+    sc::IntrusiveList<Identity> other_list;
+    other_list.splice(
+        other_list.begin(), list, std::next(list.begin()), list.end());
+
+    EXPECT(!other_list.empty());
+    EXPECT(!list.empty());
+
+    EXPECT(list.front().value == 1);
+
+    auto it = other_list.begin();
+    EXPECT((it++)->value == 2);
+    EXPECT((it++)->value == 3);
+    EXPECT(it == other_list.end());
+}
+
+auto main() -> int
+{
+    return testing::run({ TEST(should_construct_empty),
+                          TEST(should_add_item_and_not_be_empty),
+                          TEST(should_iterate_through_non_empty_list),
+                          TEST(should_remove_item),
+                          TEST(should_add_in_correct_order),
+                          TEST(should_erase_items),
+                          TEST(should_erase_and_insert),
+                          TEST(should_iterate),
+                          TEST(should_splice),
+                          TEST(should_splice_range) });
+}

--- a/tests/pool_tests.cpp
+++ b/tests/pool_tests.cpp
@@ -1,0 +1,18 @@
+#include "testing.hpp"
+#include "utils/intrusive_list.hpp"
+#include "utils/pool.hpp"
+
+struct Identity : sc::ListItemBase
+{
+};
+
+auto should_get_and_put() -> void
+{
+    sc::Pool<Identity> pool;
+
+    for (auto i = 0; i < 10; ++i) {
+        [[maybe_unused]] auto p = pool.get();
+    }
+}
+
+auto main() -> int { return testing::run({ TEST(should_get_and_put) }); }


### PR DESCRIPTION
This increases the throughput of the audio capture stage. Because of this, I've also had to change the audio encoding to a timer based approach instead of using notifications from the audio capture thread. This is because Pipewire can sometimes deliver small chunks of audio very quickly and this was saturating the processing loop, causing high CPU usage.