### PR TITLE
feat(video) Disables nvfbc push model by default

### DIFF
--- a/.versioning/changes/XRQoXRs5ej.minor.md
+++ b/.versioning/changes/XRQoXRs5ej.minor.md
@@ -1,0 +1,1 @@
+Disables NvFBC push model by default to prevent some capture artifacts

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -164,8 +164,8 @@ auto create_nvfbc_capture_session(NVFBC_SESSION_HANDLE nvfbc_handle,
     create_capture_params.bWithCursor = NVFBC_TRUE;
     create_capture_params.eTrackingType = NVFBC_TRACKING_SCREEN;
     create_capture_params.dwSamplingRateMs = 1000u / 60;
-    create_capture_params.bAllowDirectCapture = NVFBC_TRUE;
-    create_capture_params.bPushModel = NVFBC_TRUE;
+    create_capture_params.bAllowDirectCapture = NVFBC_FALSE;
+    create_capture_params.bPushModel = NVFBC_FALSE;
 
     if (nvfbc.nvFBCCreateCaptureSession(nvfbc_handle, &create_capture_params) !=
         NVFBC_SUCCESS)


### PR DESCRIPTION
Disabling `bPushModel` _appears_ to prevent an issue where a capture could present single frames from the past. It also seems to be lighter on the GPU/CPU when load or framerate is high