### PR TITLE
feat(perf) Adds multi-threaded encoding

### DIFF
--- a/.versioning/changes/uYSmfoSpCI.minor.md
+++ b/.versioning/changes/uYSmfoSpCI.minor.md
@@ -1,0 +1,1 @@
+Adds multi-threaded encoding

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,20 @@ option(
     OFF
 )
 
+option(
+    SHADOW_CAST_ENABLE_TSAN
+    "Enable TSan for ${PROJECT_NAME}"
+    OFF
+)
+
 if (SHADOW_CAST_ENABLE_ASAN)
     add_compile_options(-fsanitize=address)
     add_link_options(-fsanitize=address)
+endif()
+
+if (SHADOW_CAST_ENABLE_TSAN)
+    add_compile_options(-fsanitize=thread)
+    add_link_options(-fsanitize=thread)
 endif()
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,16 +18,17 @@ add_library(shadow-cast-obj
     handlers/video_frame_writer.cpp
 
     services/audio_service.cpp
+    services/context.cpp
     services/readiness.cpp
     services/service.cpp
     services/service_registry.cpp
+    services/signal_service.cpp
     services/video_service.cpp
-    services/context.cpp
 
+    utils/cmd_line.cpp
+    utils/base64.cpp
     utils/elapsed.cpp
     utils/result.cpp
-    utils/base64.cpp
-	utils/cmd_line.cpp
 
     error.cpp
     logging.cpp

--- a/src/handlers/stream_finalizer.cpp
+++ b/src/handlers/stream_finalizer.cpp
@@ -35,9 +35,5 @@ auto StreamFinalizer::operator()() const -> void
                    video_codec_context_.get(),
                    format_context_.get(),
                    video_stream_.get());
-
-    if (auto const ret = av_write_trailer(format_context_.get()); ret < 0)
-        throw std::runtime_error { "Failed to write trailer: " +
-                                   sc::av_error_to_string(ret) };
 }
 } // namespace sc

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -2,9 +2,10 @@
 #define SHADOW_CAST_SERVICES_HPP_INCLUDED
 
 #include "./services/audio_service.hpp"
+#include "./services/context.hpp"
 #include "./services/service.hpp"
 #include "./services/service_registry.hpp"
+#include "./services/signal_service.hpp"
 #include "./services/video_service.hpp"
-#include "./services/context.hpp"
 
 #endif // SHADOW_CAST_SERVICES_HPP_INCLUDED

--- a/src/services/audio_service.cpp
+++ b/src/services/audio_service.cpp
@@ -302,11 +302,12 @@ auto dispatch_chunks(sc::Service& svc) -> void
 
     {
         std::lock_guard data_lock { self.data_mutex_ };
-        auto it = self.available_chunks_.begin();
-        for (; it != self.available_chunks_.end(); ++it) {
-            if (!self.frame_size_ || it->sample_count < self.frame_size_)
-                break;
-        }
+        auto it = std::find_if(self.available_chunks_.begin(),
+                               self.available_chunks_.end(),
+                               [&](auto const& chunk) {
+                                   return self.frame_size_ &&
+                                          chunk.sample_count < self.frame_size_;
+                               });
 
         tmp_chunks.splice(tmp_chunks.begin(),
                           self.available_chunks_,

--- a/src/services/context.hpp
+++ b/src/services/context.hpp
@@ -2,6 +2,7 @@
 #define SHADOW_CAST_SERVICES_CONTEXT_HPP_INCLUDED
 
 #include "services/service_registry.hpp"
+#include <atomic>
 
 namespace sc
 {
@@ -14,8 +15,10 @@ struct Context
 
     auto run() -> void;
     auto services() noexcept -> ServiceRegistry&;
+    auto request_stop() noexcept -> void;
 
 private:
+    std::atomic<bool> stop_requested_ { false };
     ServiceRegistry reg_;
 };
 

--- a/src/services/signal_service.cpp
+++ b/src/services/signal_service.cpp
@@ -1,0 +1,101 @@
+#include "services/signal_service.hpp"
+#include <array>
+#include <atomic>
+#include <errno.h>
+#include <sys/signalfd.h>
+#include <system_error>
+#include <unistd.h>
+
+namespace sc
+{
+
+SignalService::SignalService()
+    : notify_fd_ { [] {
+        sigset_t empty;
+        sigemptyset(&empty);
+        return signalfd(-1, &empty, SFD_NONBLOCK);
+    }() }
+{
+    if (notify_fd_ < 0)
+        throw std::system_error { errno, std::system_category() };
+
+    if (auto const result =
+            pthread_sigmask(SIG_SETMASK, nullptr, &original_mask_);
+        result < 0)
+        throw std::system_error { errno, std::system_category() };
+}
+
+SignalService::SignalService(SignalService&& other) noexcept
+    : original_mask_ { other.original_mask_ }
+    , notify_fd_ { std::exchange(other.notify_fd_, -1) }
+    , handlers_ { std::move(other.handlers_) }
+{
+}
+
+SignalService::~SignalService() { close(notify_fd_); }
+
+auto SignalService::on_init(ReadinessRegister reg) -> void
+{
+    reg(notify_fd_, &dispatch_signal);
+}
+
+auto SignalService::on_uninit() -> void
+{
+    pthread_sigmask(SIG_SETMASK, &original_mask_, nullptr);
+}
+
+auto dispatch_signal(Service& svc) -> void
+{
+    auto& self = static_cast<SignalService&>(svc);
+
+    std::array<signalfd_siginfo, 1> buffer {};
+    auto const bytes = buffer.size() * sizeof(buffer[0]);
+
+    while (true) {
+        auto const read_result = read(self.notify_fd_, buffer.data(), bytes);
+        if (read_result < 0) {
+            if (errno == EAGAIN) {
+                break;
+            }
+            throw std::system_error { errno, std::system_category() };
+        }
+
+        auto const items = read_result / sizeof(buffer[0]);
+
+        for (auto i = 0ul; i < items; ++i) {
+            auto signo = buffer[i].ssi_signo;
+            auto handler_pos = self.handlers_.find(signo);
+            if (handler_pos == self.handlers_.end())
+                continue;
+
+            (handler_pos->second)(signo);
+        }
+
+        if (items < buffer.size())
+            break;
+    }
+}
+
+namespace detail
+{
+auto block_signal(std::uint32_t sig, int notify_fd) -> void
+{
+    sigset_t working_set;
+    if (auto const result = pthread_sigmask(SIG_SETMASK, nullptr, &working_set);
+        result < 0)
+        throw std::system_error { errno, std::system_category() };
+
+    if (auto const result = sigaddset(&working_set, sig); result < 0)
+        throw std::system_error { errno, std::system_category() };
+
+    if (auto const result = pthread_sigmask(SIG_SETMASK, &working_set, nullptr);
+        result < 0)
+        throw std::system_error { errno, std::system_category() };
+
+    if (auto const result = signalfd(notify_fd, &working_set, SFD_NONBLOCK);
+        result < 0)
+        throw std::system_error { errno, std::system_category() };
+}
+} // namespace detail
+
+} // namespace sc

--- a/src/services/signal_service.hpp
+++ b/src/services/signal_service.hpp
@@ -1,0 +1,56 @@
+#ifndef SHADOW_CAST_SERVICES_SIGNAL_SERVICE_HPP_INCLUDED
+#define SHADOW_CAST_SERVICES_SIGNAL_SERVICE_HPP_INCLUDED
+
+#include "services/service.hpp"
+#include "utils/receiver.hpp"
+#include <cinttypes>
+#include <initializer_list>
+#include <signal.h>
+#include <system_error>
+#include <unordered_map>
+#include <vector>
+
+namespace sc
+{
+
+namespace detail
+{
+auto block_signal(std::uint32_t, int) -> void;
+}
+
+struct SignalService final : Service
+{
+    friend auto dispatch_signal(Service&) -> void;
+
+    using SignalHandler = Receiver<void(std::uint32_t)>;
+
+    SignalService();
+    ~SignalService();
+
+    SignalService(SignalService&&) noexcept;
+    auto operator=(SignalService&&) noexcept = delete;
+
+    SignalService(SignalService const&) = delete;
+    auto operator=(SignalService const&) -> SignalService& = delete;
+
+    template <typename T>
+    auto add_signal_handler(std::uint32_t sig, T&& handler) -> void
+    {
+        detail::block_signal(sig, notify_fd_);
+        handlers_.emplace(sig, SignalHandler { std::forward<T>(handler) });
+    }
+
+protected:
+    auto on_init(ReadinessRegister) -> void override;
+    auto on_uninit() -> void override;
+
+private:
+    sigset_t original_mask_;
+    int notify_fd_;
+    std::unordered_map<std::uint32_t, SignalHandler> handlers_;
+};
+
+auto dispatch_signal(Service&) -> void;
+} // namespace sc
+
+#endif // SHADOW_CAST_SERVICES_SIGNAL_SERVICE_HPP_INCLUDEDq


### PR DESCRIPTION
This commit splits the audio and video processing loops among two separate threads. This ensures that processing a frame of either doesn't starve the other.