### PR TITLE
fix(encoding) Removes unnecessary thread synchronization

### DIFF
--- a/.versioning/changes/393VMmkUWr.minor.md
+++ b/.versioning/changes/393VMmkUWr.minor.md
@@ -1,0 +1,1 @@
+Removes unnecessary thread synchronization to reduce contention

--- a/src/handlers/audio_chunk_writer.cpp
+++ b/src/handlers/audio_chunk_writer.cpp
@@ -31,13 +31,10 @@ auto send_frame(AVFrame* frame,
     PacketPtr packet { av_packet_alloc(),
                        [](auto pkt) { av_packet_free(&pkt); } };
 
-    auto response = invoke_synchronized(
-        send_frame_mutex, [&] { return avcodec_send_frame(ctx, frame); });
+    auto response = avcodec_send_frame(ctx, frame);
 
     while (response >= 0) {
-        response = invoke_synchronized(send_frame_mutex, [&] {
-            return avcodec_receive_packet(ctx, packet.get());
-        });
+        response = avcodec_receive_packet(ctx, packet.get());
         if (response == AVERROR(EAGAIN) || response == AVERROR_EOF) {
             break;
         }


### PR DESCRIPTION
It appears synchronization is only required on when writing packets to the output, and not required when sending frames to / dequeuing packets from the encoder.