### PR TITLE
fix(encoding) Removes excess AVPacket allocations

### DIFF
--- a/.versioning/changes/W3KePUgugT.minor.md
+++ b/.versioning/changes/W3KePUgugT.minor.md
@@ -1,0 +1,1 @@
+Removes excess `AVPacket` allocations

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(shadow-cast-obj
     av/format.cpp
     av/frame.cpp
     av/media_chunk.cpp
+    av/packet.cpp
     av/sample_format.cpp
 
     display/display.cpp

--- a/src/av.hpp
+++ b/src/av.hpp
@@ -8,6 +8,7 @@
 #include "./av/frame.hpp"
 #include "./av/fwd.hpp"
 #include "./av/media_chunk.hpp"
+#include "./av/packet.hpp"
 #include "./av/sample_format.hpp"
 
 #endif // SHADOW_CAST_AV_HPP_INCLUDED

--- a/src/av/frame.cpp
+++ b/src/av/frame.cpp
@@ -1,5 +1,21 @@
 #include "av/frame.hpp"
+#include "av/packet.hpp"
+#include "error.hpp"
+#include <mutex>
 #include <stdexcept>
+
+std::mutex send_frame_mutex {};
+
+namespace
+{
+template <typename F>
+auto invoke_synchronized(std::mutex& mutex, F&& f)
+{
+    std::lock_guard lock { mutex };
+    return std::forward<F>(f)();
+}
+
+} // namespace
 
 namespace sc
 {
@@ -9,11 +25,42 @@ auto FrameDeleter::operator()(AVFrame* ptr) const noexcept -> void
     av_frame_free(&ptr);
 }
 
-
 AVFrameUnrefGuard::~AVFrameUnrefGuard()
 {
     if (frame)
         av_frame_unref(frame.get());
 }
 
+auto send_frame(AVFrame* frame,
+                AVCodecContext* ctx,
+                AVFormatContext* fmt,
+                AVStream* stream,
+                AVPacket* packet) -> void
+{
+    auto response = avcodec_send_frame(ctx, frame);
+
+    while (response >= 0) {
+        response = avcodec_receive_packet(ctx, packet);
+        if (response == AVERROR(EAGAIN) || response == AVERROR_EOF) {
+            break;
+        }
+
+        if (response < 0) {
+            throw std::runtime_error { "receive packet error" };
+        }
+
+        PacketUnrefGuard packet_unref_guard { packet };
+
+        packet->stream_index = stream->index;
+        av_packet_rescale_ts(packet, ctx->time_base, stream->time_base);
+
+        response = invoke_synchronized(send_frame_mutex, [&] {
+            return av_interleaved_write_frame(fmt, packet);
+        });
+        if (response < 0) {
+            throw std::runtime_error { "write packet error: " +
+                                       av_error_to_string(response) };
+        }
+    }
+}
 } // namespace sc

--- a/src/av/frame.hpp
+++ b/src/av/frame.hpp
@@ -20,6 +20,12 @@ struct AVFrameUnrefGuard
     sc::BorrowedPtr<AVFrame> frame;
 };
 
+auto send_frame(AVFrame* frame,
+                AVCodecContext* ctx,
+                AVFormatContext* fmt,
+                AVStream* stream,
+                AVPacket* packet) -> void;
+
 } // namespace sc
 
 #endif // SHADOW_CAST_AV_FRAME_HPP_INCLUDED

--- a/src/av/packet.cpp
+++ b/src/av/packet.cpp
@@ -1,0 +1,12 @@
+#include "av/packet.hpp"
+
+namespace sc
+{
+auto PacketPtrDeleter::operator()(AVPacket* ptr) const noexcept -> void
+{
+    av_packet_free(&ptr);
+}
+
+PacketUnrefGuard::~PacketUnrefGuard() { av_packet_unref(packet); }
+
+} // namespace sc

--- a/src/av/packet.hpp
+++ b/src/av/packet.hpp
@@ -1,0 +1,25 @@
+#ifndef SHADOW_CAST_AV_PACKET_HPP_INCLUDED
+#define SHADOW_CAST_AV_PACKET_HPP_INCLUDED
+
+#include "./fwd.hpp"
+#include <memory>
+
+namespace sc
+{
+
+struct PacketPtrDeleter
+{
+    auto operator()(AVPacket* ptr) const noexcept -> void;
+};
+
+struct PacketUnrefGuard
+{
+    ~PacketUnrefGuard();
+
+    AVPacket* packet;
+};
+
+using PacketPtr = std::unique_ptr<AVPacket, PacketPtrDeleter>;
+
+} // namespace sc
+#endif // SHADOW_CAST_AV_PACKET_HPP_INCLUDED

--- a/src/handlers/audio_chunk_writer.cpp
+++ b/src/handlers/audio_chunk_writer.cpp
@@ -1,60 +1,14 @@
 #include "handlers/audio_chunk_writer.hpp"
+#include "av/frame.hpp"
 #include "av/sample_format.hpp"
 #include "error.hpp"
 #include <algorithm>
 #include <cassert>
 #include <memory>
-#include <mutex>
 #include <numeric>
-
-std::mutex send_frame_mutex {};
-
-namespace
-{
-template <typename F>
-auto invoke_synchronized(std::mutex& mutex, F&& f)
-{
-    std::lock_guard lock { mutex };
-    return std::forward<F>(f)();
-}
-
-} // namespace
 
 namespace sc
 {
-auto send_frame(AVFrame* frame,
-                AVCodecContext* ctx,
-                AVFormatContext* fmt,
-                AVStream* stream) -> void
-{
-    using PacketPtr = std::unique_ptr<AVPacket, auto(*)(AVPacket*)->void>;
-    PacketPtr packet { av_packet_alloc(),
-                       [](auto pkt) { av_packet_free(&pkt); } };
-
-    auto response = avcodec_send_frame(ctx, frame);
-
-    while (response >= 0) {
-        response = avcodec_receive_packet(ctx, packet.get());
-        if (response == AVERROR(EAGAIN) || response == AVERROR_EOF) {
-            break;
-        }
-
-        if (response < 0) {
-            throw std::runtime_error { "receive packet error" };
-        }
-
-        packet->stream_index = stream->index;
-        av_packet_rescale_ts(packet.get(), ctx->time_base, stream->time_base);
-
-        response = invoke_synchronized(send_frame_mutex, [&] {
-            return av_interleaved_write_frame(fmt, packet.get());
-        });
-        if (response < 0) {
-            throw std::runtime_error { "write packet error: " +
-                                       av_error_to_string(response) };
-        }
-    }
-}
 
 ChunkWriter::ChunkWriter(AVFormatContext* format_context,
                          AVCodecContext* codec_context,
@@ -64,6 +18,7 @@ ChunkWriter::ChunkWriter(AVFormatContext* format_context,
     , stream_ { stream }
     , frame_ { av_frame_alloc() }
     , total_samples_written_ { 0 }
+    , packet_ { av_packet_alloc() }
 {
 }
 
@@ -107,7 +62,8 @@ auto ChunkWriter::operator()(MediaChunk const& chunk) -> void
     send_frame(frame.get(),
                codec_context_.get(),
                format_context_.get(),
-               stream_.get());
+               stream_.get(),
+               packet_.get());
 }
 
 } // namespace sc

--- a/src/handlers/audio_chunk_writer.hpp
+++ b/src/handlers/audio_chunk_writer.hpp
@@ -21,12 +21,8 @@ private:
     BorrowedPtr<AVStream> stream_;
     FramePtr frame_;
     std::size_t total_samples_written_ { 0 };
+    PacketPtr packet_;
 };
-
-auto send_frame(AVFrame* frame,
-                AVCodecContext* ctx,
-                AVFormatContext* fmt,
-                AVStream* stream) -> void;
 
 } // namespace sc
 

--- a/src/handlers/stream_finalizer.cpp
+++ b/src/handlers/stream_finalizer.cpp
@@ -1,6 +1,6 @@
 #include "handlers/stream_finalizer.hpp"
+#include "av/frame.hpp"
 #include "error.hpp"
-#include "handlers/audio_chunk_writer.hpp"
 #include <stdexcept>
 
 namespace sc
@@ -17,6 +17,7 @@ StreamFinalizer::StreamFinalizer(
     , video_codec_context_ { video_codec_context }
     , audio_stream_ { audio_stream }
     , video_stream_ { video_stream }
+    , packet_ { av_packet_alloc() }
 {
 }
 
@@ -24,16 +25,18 @@ auto StreamFinalizer::operator()() const -> void
 {
     /* Send a end marker to the audio stream...
      */
-    sc::send_frame(nullptr,
-                   audio_codec_context_.get(),
-                   format_context_.get(),
-                   audio_stream_.get());
+    send_frame(nullptr,
+               audio_codec_context_.get(),
+               format_context_.get(),
+               audio_stream_.get(),
+               packet_.get());
 
     /* Hijack this handler to send an end marker to the video stream, too...
      */
-    sc::send_frame(nullptr,
-                   video_codec_context_.get(),
-                   format_context_.get(),
-                   video_stream_.get());
+    send_frame(nullptr,
+               video_codec_context_.get(),
+               format_context_.get(),
+               video_stream_.get(),
+               packet_.get());
 }
 } // namespace sc

--- a/src/handlers/stream_finalizer.hpp
+++ b/src/handlers/stream_finalizer.hpp
@@ -2,6 +2,7 @@
 #define SHADOW_CAST_HANDLERS_STREAM_FINALIZER_HPP_INCLUDED
 
 #include "av/fwd.hpp"
+#include "av/packet.hpp"
 #include "utils/borrowed_ptr.hpp"
 
 namespace sc
@@ -23,6 +24,7 @@ private:
     BorrowedPtr<AVCodecContext> video_codec_context_;
     BorrowedPtr<AVStream> audio_stream_;
     BorrowedPtr<AVStream> video_stream_;
+    PacketPtr packet_;
 };
 
 } // namespace sc

--- a/src/handlers/video_frame_writer.cpp
+++ b/src/handlers/video_frame_writer.cpp
@@ -13,6 +13,7 @@ VideoFrameWriter::VideoFrameWriter(AVFormatContext* fmt_context,
     , codec_context_ { codec_context }
     , stream_ { stream }
     , frame_ { av_frame_alloc() }
+    , packet_ { av_packet_alloc() }
 {
 }
 
@@ -50,10 +51,11 @@ auto VideoFrameWriter::operator()(CUdeviceptr cu_device_ptr,
 
     frame_->pts = frame_number_++;
 
-    sc::send_frame(frame_.get(),
-                   codec_context_.get(),
-                   format_context_.get(),
-                   stream_.get());
+    send_frame(frame_.get(),
+               codec_context_.get(),
+               format_context_.get(),
+               stream_.get(),
+               packet_.get());
 }
 
 } // namespace sc

--- a/src/handlers/video_frame_writer.hpp
+++ b/src/handlers/video_frame_writer.hpp
@@ -15,11 +15,12 @@ struct VideoFrameWriter
     auto operator()(CUdeviceptr cu_device_ptr, NVFBC_FRAME_GRAB_INFO) -> void;
 
 private:
-    sc::BorrowedPtr<AVFormatContext> format_context_;
-    sc::BorrowedPtr<AVCodecContext> codec_context_;
-    sc::BorrowedPtr<AVStream> stream_;
-    sc::FramePtr frame_;
+    BorrowedPtr<AVFormatContext> format_context_;
+    BorrowedPtr<AVCodecContext> codec_context_;
+    BorrowedPtr<AVStream> stream_;
+    FramePtr frame_;
     std::size_t frame_number_ { 0 };
+    PacketPtr packet_;
 };
 
 } // namespace sc


### PR DESCRIPTION
`AVPacket`s can be allocated once and unref'd to reuse again to dequeue another.