### PR TITLE
feat(capture) Adds DRM capture for Wayland support

### DIFF
--- a/.versioning/changes/r5eVh9AAbK.minor.md
+++ b/.versioning/changes/r5eVh9AAbK.minor.md
@@ -1,0 +1,1 @@
+Adds Wayland support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ find_package(
         swscale
 )
 find_package(X11 REQUIRED)
+find_package(DRM REQUIRED)
 
 option(
     SHADOW_CAST_ENABLE_TESTS
@@ -77,7 +78,17 @@ if(SHADOW_CAST_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
 
+configure_file(
+    tools/install-helper.sh.in
+    install-helper.sh
+    FILE_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_WRITE
+        WORLD_READ WORLD_WRITE
+    @ONLY
+)
+
 install(
-    TARGETS shadow-cast
+    TARGETS shadow-cast shadow-cast-kms
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ctrl+C / SIGINT will stop the capture session and finalize the output media.
 ### Help. I'm getting the following error
 
 #### `ERROR: Couldn't create NvFBC instance`
-*Shadow Cast* uses the *NvFBC* facility to provide efficient, low-latency framebuffer capture. By default, NVIDIA disables this on most (if not all) of its consumer-level GPUs. However, there are two ways around this restriction...
+*Shadow Cast* uses the *NvFBC* facility to provide efficient, low-latency framebuffer capture on X11. By default, NVIDIA disables this on most (if not all) of its consumer-level GPUs. However, there are two ways around this restriction...
 
 - You can find a utility to patch your NVIDIA drivers in the [keylase/nvidia-patch](https://github.com/keylase/nvidia-patch) GitHub repo.
 - You can obtain a "key" to unlock this feature at runtime. The key can be set at runtime via the `SHADOW_CAST_NVFBC_KEY=<BASE64 ENCODED KEY>` environment variable. I use this method but I'm not sure how "official" it is, so no keys are provided in this repo. Feel free to message me about this.
@@ -45,14 +45,16 @@ Ctrl+C / SIGINT will stop the capture session and finalize the output media.
 - FFMpeg (libav)
 - NVIDIA GPU, supporting NVENC and NvFBC
 - Pipewire
-- X11
+- X11 or Wayland
 
 ### Building from source
-In order to build *Shadow Cast* you will need the following libraries' headers/libs installed...
+In order to build *Shadow Cast* you will need a C++20 compiler, plus the following libraries' headers/libs installed...
 
 - ffmpeg / libav
 - X11
 - Pipewire
+- Wayland (wayland-client, wayland-egl)
+- libdrm
 
 These can usually be obtained through your Linux distribution's package manager using the `-devel` packages of each.
 
@@ -65,15 +67,27 @@ $ cmake ..
 $ cmake --build .
 ```
 
+_TIP: You may be able to speed up the_ `cmake --build .` _step by appending_ ` -- -j$(nproc)`
+
 ### Installing
 
 Following the steps to build, above, you can install the built binary using...
 
 ```
-$ sudo cmake --build . --target install
+$ sudo ./install-helper.sh
 ```
 
-By default, this will install the `shadow-cast` binary to `/usr/local/bin`
+#### Installing to a Different Location
+
+By default, *Shadow Cast* will be installed to `/usr/local/bin`. If you wish to install to a different location, run the following command _before_ running the above install step...
+
+```
+$ cmake -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> ..
+```
+
+... replacing `<INSTALL_DIR>` with your custom install path (E.g. `$HOME/.local`, `/opt`, etc.)
+
+This will install the binary to `<INSTALL_DIR>/bin/shadow-cast`. Once installed, you must ensure that `<INSTALL_DIR>/bin` is in your `$PATH`.
 
 ### Some Alternative Projects
 #### [gpu-screen-recorder](https://git.dec05eba.com/gpu-screen-recorder/about/)

--- a/cmake/FindDRM.cmake
+++ b/cmake/FindDRM.cmake
@@ -1,0 +1,55 @@
+find_package(PkgConfig REQUIRED)
+include(FindPackageHandleStandardArgs)
+
+pkg_check_modules(PC_DRM QUIET "libdrm")
+
+find_path(DRM_INCLUDE_DIR
+    NAMES drm.h
+    PATHS "${PC_DRM_INCLUDE_DIRS}"
+    PATH_SUFFIXES "libdrm"
+)
+
+find_library(DRM_LIBRARY
+    NAMES drm
+    PATHS "${PC_DRM_LIBRARY_DIRS}"
+)
+
+find_package_handle_standard_args(DRM
+    FOUND_VAR DRM_FOUND
+    REQUIRED_VARS
+        DRM_LIBRARY
+        DRM_INCLUDE_DIR
+)
+
+if (DRM_FOUND)
+    # Include the found directory. Needed for including
+    # `xf86drm.h`...
+    list(APPEND DRM_INCLUDE_DIRS "${DRM_INCLUDE_DIR}")
+
+    # Set the include dir up one level so that dependent
+    # targets have to use `#include <libdrm/...>`. This
+    # prevents any clashing header names...
+    if (DRM_INCLUDE_DIR MATCHES "\/libdrm$")
+        get_filename_component(
+            DRM_INCLUDE_DIR
+            "${DRM_INCLUDE_DIR}"
+            DIRECTORY
+        )
+        list(APPEND DRM_INCLUDE_DIRS "${DRM_INCLUDE_DIR}")
+    endif ()
+    set(DRM_LIBRARIES ${DRM_LIBRARY})
+    set(DRM_DEFINITIONS ${PC_DRM_CFLAGS_OTHER})
+endif ()
+
+if (DRM_FOUND)
+    message(STATUS "DRM_INCLUDE_DIRS: ${DRM_INCLUDE_DIRS}")
+    message(STATUS "DRM_LIBRARY: ${DRM_INCLUDE_DIR}")
+    add_library(DRM::drm UNKNOWN IMPORTED)
+    set_target_properties(
+        DRM::drm
+        PROPERTIES
+            IMPORTED_LOCATION "${DRM_LIBRARY}"
+            INTERFACE_COMPILE_OPTIONS "${PC_DRM_CGLAGS_OTHER}"
+            INTERFACE_INCLUDE_DIRECTORIES "${DRM_INCLUDE_DIRS}"
+    )
+endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,12 +16,25 @@ add_library(shadow-cast-obj
 
     display/display.cpp
 
-	handlers/stream_finalizer.cpp
+    drm/messaging.cpp
+    drm/planes.cpp
+
     handlers/audio_chunk_writer.cpp
+    handlers/drm_video_frame_writer.cpp
+	handlers/stream_finalizer.cpp
     handlers/video_frame_writer.cpp
+
+    io/accept_handler.cpp
+    io/process.cpp
+    io/signals.cpp
+    io/unix_socket.cpp
+
+    platform/egl.cpp
+    platform/wayland.cpp
 
     services/audio_service.cpp
     services/context.cpp
+    services/drm_video_service.cpp
     services/readiness.cpp
     services/service.cpp
     services/service_registry.cpp
@@ -29,6 +42,7 @@ add_library(shadow-cast-obj
     services/video_service.cpp
 
     utils/cmd_line.cpp
+    utils/contracts.cpp
     utils/base64.cpp
     utils/elapsed.cpp
     utils/result.cpp
@@ -57,6 +71,8 @@ target_link_libraries(shadow-cast-obj
     FFMpeg::swscale
     pthread
     X11::X11
+    wayland-client
+    wayland-egl
 )
 
 add_executable(shadow-cast
@@ -66,4 +82,26 @@ add_executable(shadow-cast
 target_link_libraries(shadow-cast
     PRIVATE
     shadow-cast-obj
+)
+
+set(
+    SHADOW_CAST_KMS_BINARY_NAME
+    "shadow-cast-kms"
+    PARENT_SCOPE
+)
+
+add_executable(shadow-cast-kms
+    kms.cpp
+)
+
+set_target_properties(
+    shadow-cast-kms
+    PROPERTIES
+        OUTPUT_NAME "${SHADOW_CAST_KMS_BINARY_NAME}"
+)
+
+target_link_libraries(shadow-cast-kms
+    PRIVATE
+    shadow-cast-obj
+    DRM::drm
 )

--- a/src/av/codec.hpp
+++ b/src/av/codec.hpp
@@ -14,12 +14,19 @@ struct CodecContextDeleter
     auto operator()(AVCodecContext* ptr) noexcept -> void;
 };
 
+struct VideoOutputSize
+{
+    std::uint32_t width;
+    std::uint32_t height;
+};
+
 using CodecContextPtr = std::unique_ptr<AVCodecContext, CodecContextDeleter>;
 auto create_video_encoder(std::string const& encoder_name,
                           CUcontext cuda_ctx,
                           AVBufferPool* pool,
-                          Display* display,
-                          std::uint32_t fps) -> sc::CodecContextPtr;
+                          VideoOutputSize size,
+                          std::uint32_t fps,
+                          AVPixelFormat pixel_format) -> sc::CodecContextPtr;
 } // namespace sc
 
 #endif // SHADOW_CAST_AV_CODEC_HPP_INCLUDED

--- a/src/drm.hpp
+++ b/src/drm.hpp
@@ -1,0 +1,7 @@
+#ifndef SHADOW_CAST_DRM_HPP_INCLUDED
+#define SHADOW_CAST_DRM_HPP_INCLUDED
+
+#include "./drm/messaging.hpp"
+#include "./drm/planes.hpp"
+
+#endif // SHADOW_CAST_DRM_HPP_INCLUDED

--- a/src/drm/messaging.cpp
+++ b/src/drm/messaging.cpp
@@ -1,0 +1,80 @@
+#include "drm/messaging.hpp"
+#include <span>
+#include <sys/socket.h>
+
+namespace sc
+{
+
+auto DRMResponseSendHandler::operator()(int fd,
+                                        msghdr& msg,
+                                        DRMResponse const& response) noexcept
+    -> ssize_t
+{
+    /* The use of the control messages is significant
+     * here; They are the _only_ valid way to transport
+     * file descriptors via a unix socket. The kernel
+     * must somehow know to marshal them correctly
+     * between processes.
+     * NOTE: _It's important to set the length of
+     * the control message (`cmsg_len`) to the exact
+     * size of the number of descriptors. Setting this
+     * value higher cause issues when subsequently using
+     * the descriptors_
+     */
+
+    SC_EXPECT(response.num_fds <= kMaxPlaneDescriptors);
+    char cmsgbuf[CMSG_SPACE(sizeof(int) * kMaxPlaneDescriptors)];
+    std::memset(cmsgbuf, 0, sizeof(int) * kMaxPlaneDescriptors);
+
+    if (response.num_fds) {
+
+        msg.msg_control = cmsgbuf;
+        msg.msg_controllen = CMSG_SPACE(sizeof(int) * response.num_fds);
+
+        cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+        cmsg->cmsg_level = SOL_SOCKET;
+        cmsg->cmsg_type = SCM_RIGHTS;
+        cmsg->cmsg_len = CMSG_LEN(sizeof(int) * response.num_fds);
+
+        int* fds = reinterpret_cast<int*>(CMSG_DATA(cmsg));
+        std::span<PlaneDescriptor const> descriptors { response.descriptors,
+                                                       response.num_fds };
+        for (auto const& desc : descriptors)
+            *fds++ = desc.fd;
+    }
+
+    return ::sendmsg(fd, &msg, 0);
+}
+
+auto DRMResponseReceiveHandler::operator()(int fd,
+                                           msghdr& msg,
+                                           DRMResponse& response) noexcept
+    -> ssize_t
+{
+    /* Here, we pluck the file descriptors from the control
+     * message and update the response message payload
+     */
+
+    char cmsgbuf[CMSG_SPACE(sizeof(int) * kMaxPlaneDescriptors)] {};
+    msg.msg_control = cmsgbuf;
+    msg.msg_controllen = sizeof(cmsgbuf);
+
+    int res = ::recvmsg(fd, &msg, MSG_WAITALL);
+    if (res <= 0)
+        return res;
+
+    if (response.num_fds > 0) {
+        cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+        std::span<int> fds { reinterpret_cast<int*>(CMSG_DATA(cmsg)),
+                             response.num_fds };
+
+        SC_EXPECT(response.num_fds <= fds.size());
+        for (std::uint32_t i = 0; i < response.num_fds; ++i) {
+            response.descriptors[i].fd = fds[i];
+        }
+    }
+
+    return res;
+}
+
+} // namespace sc

--- a/src/drm/messaging.hpp
+++ b/src/drm/messaging.hpp
@@ -1,0 +1,48 @@
+#ifndef SHADOW_CAST_DRM_MESSAGING_HPP_INCLUDED
+#define SHADOW_CAST_DRM_MESSAGING_HPP_INCLUDED
+
+#include "drm/planes.hpp"
+#include "io/message_handler.hpp"
+
+namespace sc
+{
+
+std::size_t constexpr kMaxPlaneDescriptors = 8;
+
+namespace drm_request
+{
+[[maybe_unused]] std::uint32_t constexpr kGetPlanes = 1;
+[[maybe_unused]] std::uint32_t constexpr kStop = 2;
+} // namespace drm_request
+
+struct DRMRequest
+{
+    std::uint32_t type;
+};
+
+struct DRMResponse
+{
+    std::uint32_t result;
+    std::uint32_t num_fds;
+    PlaneDescriptor descriptors[kMaxPlaneDescriptors];
+};
+
+struct DRMResponseSendHandler
+{
+    auto operator()(int, msghdr&, DRMResponse const&) noexcept -> ssize_t;
+};
+
+struct DRMResponseReceiveHandler
+{
+    auto operator()(int, msghdr&, DRMResponse&) noexcept -> ssize_t;
+};
+
+using DRMResponseSender =
+    MessageHandler<DRMResponse, DRMResponseSendHandler, decltype(io::write)>;
+
+using DRMResponseReceiver =
+    MessageHandler<DRMResponse, DRMResponseReceiveHandler, decltype(io::write)>;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_DRM_MESSAGING_HPP_INCLUDED

--- a/src/drm/planes.cpp
+++ b/src/drm/planes.cpp
@@ -1,0 +1,17 @@
+#include "drm/planes.hpp"
+
+namespace sc
+{
+
+auto PlaneDescriptor::set_flag(plane_flags::PlaneFlags flag) noexcept -> void
+{
+    flags |= flag;
+}
+
+auto PlaneDescriptor::is_flag_set(plane_flags::PlaneFlags flag) const noexcept
+    -> bool
+{
+    return (flags & flag) != 0;
+}
+
+} // namespace sc

--- a/src/drm/planes.hpp
+++ b/src/drm/planes.hpp
@@ -1,0 +1,44 @@
+#ifndef SHADOW_CAST_DRM_PLANES_HPP_INCLUDED
+#define SHADOW_CAST_DRM_PLANES_HPP_INCLUDED
+
+#include <cinttypes>
+#include <cstddef>
+
+namespace sc
+{
+
+namespace plane_flags
+{
+
+enum PlaneFlags : std::uint32_t
+{
+    IS_CURSOR = (1 << 0),
+    IS_COMBINED = (1 << 1)
+};
+
+}
+
+struct PlaneDescriptor
+{
+    int fd;
+    uint32_t width;
+    uint32_t height;
+    uint32_t pitch;
+    uint32_t offset;
+    uint32_t pixel_format;
+    uint64_t modifier;
+    uint32_t connector_id;
+    uint32_t flags;
+    // bool is_combined_plane;
+    // bool is_cursor;
+    int x;
+    int y;
+    int src_w;
+    int src_h;
+
+    auto set_flag(plane_flags::PlaneFlags /* flag */) noexcept -> void;
+    auto is_flag_set(plane_flags::PlaneFlags /* flag */) const noexcept -> bool;
+};
+} // namespace sc
+
+#endif // SHADOW_CAST_DRM_PLANES_HPP_INCLUDED

--- a/src/handlers.hpp
+++ b/src/handlers.hpp
@@ -2,6 +2,7 @@
 #define SHADOW_CAST_HANDLERS_HPP_INCLUDED
 
 #include "./handlers/audio_chunk_writer.hpp"
+#include "./handlers/drm_video_frame_writer.hpp"
 #include "./handlers/stream_finalizer.hpp"
 #include "./handlers/video_frame_writer.hpp"
 

--- a/src/handlers/drm_video_frame_writer.cpp
+++ b/src/handlers/drm_video_frame_writer.cpp
@@ -1,0 +1,69 @@
+#include "handlers/drm_video_frame_writer.hpp"
+#include "utils/elapsed.hpp"
+
+namespace sc
+{
+
+DRMVideoFrameWriter::DRMVideoFrameWriter(AVFormatContext* fmt_context,
+                                         AVCodecContext* codec_context,
+                                         AVStream* stream)
+    : format_context_ { fmt_context }
+    , codec_context_ { codec_context }
+    , stream_ { stream }
+    , frame_ { av_frame_alloc() }
+    , packet_ { av_packet_alloc() }
+{
+    frame_->format = codec_context_->pix_fmt;
+    frame_->width = codec_context_->width;
+    frame_->height = codec_context_->height;
+    frame_->color_range = codec_context_->color_range;
+    frame_->color_primaries = codec_context_->color_primaries;
+    frame_->color_trc = codec_context_->color_trc;
+    frame_->colorspace = codec_context_->colorspace;
+    frame_->chroma_location = codec_context_->chroma_sample_location;
+    if (auto const r = av_hwframe_get_buffer(
+            codec_context_->hw_frames_ctx, frame_.get(), 0);
+        r < 0)
+        throw std::runtime_error { "Failed to get H/W frame buffer" };
+}
+
+auto DRMVideoFrameWriter::operator()(CUarray data, NvCuda const& cuda) -> void
+{
+    SC_EXPECT(data);
+    SC_EXPECT(frame_->linesize[0]);
+    SC_EXPECT(frame_->height);
+    SC_EXPECT(frame_->data[0]);
+
+    CUDA_MEMCPY2D memcpy_struct {};
+
+    memcpy_struct.srcXInBytes = 0;
+    memcpy_struct.srcY = 0;
+    memcpy_struct.srcMemoryType = CU_MEMORYTYPE_ARRAY;
+    memcpy_struct.dstXInBytes = 0;
+    memcpy_struct.dstY = 0;
+    memcpy_struct.dstMemoryType = CU_MEMORYTYPE_DEVICE;
+    memcpy_struct.srcArray = data;
+    memcpy_struct.dstDevice = reinterpret_cast<CUdeviceptr>(frame_->data[0]);
+    memcpy_struct.dstPitch = frame_->linesize[0];
+    memcpy_struct.WidthInBytes = frame_->linesize[0];
+    memcpy_struct.Height = frame_->height;
+
+    if (auto const r = cuda.cuMemcpy2D_v2(&memcpy_struct); r != CUDA_SUCCESS) {
+        char const* err = "unknown";
+        cuda.cuGetErrorString(r, &err);
+        throw std::runtime_error {
+            std::to_string(frame_number_) +
+            std::string { " Failed to copy CUDA buffer: " } + err
+        };
+    }
+
+    frame_->pts = frame_number_++;
+
+    send_frame(frame_.get(),
+               codec_context_.get(),
+               format_context_.get(),
+               stream_.get(),
+               packet_.get());
+}
+
+} // namespace sc

--- a/src/handlers/drm_video_frame_writer.hpp
+++ b/src/handlers/drm_video_frame_writer.hpp
@@ -1,0 +1,28 @@
+#ifndef SHADOW_CAST_HANDLERS_DRM_VIDEO_FRAME_WRITER_HPP_INCLUDED
+#define SHADOW_CAST_HANDLERS_DRM_VIDEO_FRAME_WRITER_HPP_INCLUDED
+
+#include "av.hpp"
+#include "nvidia.hpp"
+
+namespace sc
+{
+struct DRMVideoFrameWriter
+{
+    DRMVideoFrameWriter(AVFormatContext* fmt_context,
+                        AVCodecContext* codec_context,
+                        AVStream* stream);
+
+    auto operator()(CUarray, NvCuda const&) -> void;
+
+private:
+    BorrowedPtr<AVFormatContext> format_context_;
+    BorrowedPtr<AVCodecContext> codec_context_;
+    BorrowedPtr<AVStream> stream_;
+    FramePtr frame_;
+    std::size_t frame_number_ { 0 };
+    PacketPtr packet_;
+};
+
+} // namespace sc
+
+#endif // SHADOW_CAST_HANDLERS_DRM_VIDEO_FRAME_WRITER_HPP_INCLUDED

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -1,0 +1,11 @@
+#ifndef SHADOW_CAST_IO_HPP_INCLUDED
+#define SHADOW_CAST_IO_HPP_INCLUDED
+
+#include "./io/accept_handler.hpp"
+#include "./io/message_receiver.hpp"
+#include "./io/message_sender.hpp"
+#include "./io/process.hpp"
+#include "./io/signals.hpp"
+#include "./io/unix_socket.hpp"
+
+#endif // SHADOW_CAST_IO_HPP_INCLUDED

--- a/src/io/accept_handler.cpp
+++ b/src/io/accept_handler.cpp
@@ -1,0 +1,58 @@
+#include "io/accept_handler.hpp"
+#include <sys/socket.h>
+#include <sys/un.h>
+
+namespace sc
+{
+AcceptHandler::AcceptHandler(std::size_t tout, sigset_t* mask) noexcept
+    : timeout_ms_ { tout }
+    , sigmask_ { mask }
+{
+}
+
+auto AcceptHandler::operator()(int fd) noexcept -> Result<int, std::error_code>
+{
+    pollfd pfd[1] = {};
+    pfd[0].fd = fd;
+    pfd[0].events = POLLIN;
+
+    timespec ts_storage = {};
+    timespec* ts = nullptr;
+    if (timeout_ms_ != timeout::kInfinite) {
+        ts_storage = { .tv_sec = static_cast<time_t>(timeout_ms_ / 1'000),
+                       .tv_nsec = static_cast<time_t>((timeout_ms_ % 1'000) *
+                                                      1'000'000) };
+        ts = &ts_storage;
+    }
+
+    /* NOTE:
+     * sigmask_ should be the *INVERSE* of the signals that we
+     * want to be notified on. E.g. if we're currently blocking
+     * SIGINT, and we wish for ppoll to tell us if a SIGINT
+     * occurred, then `sigmask_` *MUST NOT* contain SIGINT.
+     *
+     * Essentially, the current mask will be *SET* to `sigmask_`
+     * for the duration of `ppoll()`, and will be restored to
+     * its previous value after the call. If a signal occurs
+     * the `ppoll()` will return `EINTR`...
+     */
+    auto const poll_result = ::ppoll(pfd, 1, ts, sigmask_);
+
+    if (poll_result < 0)
+        return result_error(std::error_code { errno, std::system_category() });
+
+    if (poll_result == 0)
+        return result_error(
+            std::error_code { ETIMEDOUT, std::system_category() });
+
+    sockaddr_un remote_addr;
+    socklen_t len = sizeof(sockaddr_un);
+    auto const accept_result =
+        ::accept(fd, reinterpret_cast<sockaddr*>(&remote_addr), &len);
+    if (accept_result < 0)
+        return result_error(std::error_code { errno, std::system_category() });
+
+    return result_ok(accept_result);
+}
+
+} // namespace sc

--- a/src/io/accept_handler.hpp
+++ b/src/io/accept_handler.hpp
@@ -1,0 +1,23 @@
+#ifndef SHADOW_CAST_IO_ACCEPT_HANDLE_HPP_INCLUDED
+#define SHADOW_CAST_IO_ACCEPT_HANDLE_HPP_INCLUDED
+
+#include "io/message_handler.hpp"
+#include <cstddef>
+#include <signal.h>
+#include <system_error>
+
+namespace sc
+{
+struct AcceptHandler
+{
+    explicit AcceptHandler(std::size_t /*timeout_ms*/ = timeout::kInfinite,
+                           sigset_t* /*sigmask*/ = nullptr) noexcept;
+
+    auto operator()(int /*fd*/) noexcept -> Result<int, std::error_code>;
+
+private:
+    std::size_t timeout_ms_;
+    sigset_t* sigmask_;
+};
+} // namespace sc
+#endif // SHADOW_CAST_IO_ACCEPT_HANDLE_HPP_INCLUDED

--- a/src/io/message_handler.hpp
+++ b/src/io/message_handler.hpp
@@ -1,0 +1,110 @@
+#ifndef SHADOW_CAST_IO_MESSAGE_HANDLER_HPP_INCLUDED
+#define SHADOW_CAST_IO_MESSAGE_HANDLER_HPP_INCLUDED
+
+#include "utils/contracts.hpp"
+#include "utils/result.hpp"
+#include <cinttypes>
+#include <cstddef>
+#include <cstring>
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <system_error>
+
+namespace sc
+{
+
+namespace timeout
+{
+std::size_t constexpr kInfinite = static_cast<std::size_t>(-1);
+}
+
+namespace io
+{
+constexpr struct
+{
+} read;
+constexpr struct
+{
+} write;
+} // namespace io
+
+template <typename T, typename Handler, typename Direction>
+requires(std::is_same_v<Direction, decltype(io::read)> ||
+         std::is_same_v<Direction, decltype(io::write)>)
+struct MessageHandler
+{
+
+    explicit MessageHandler(T& payload,
+                            std::size_t timeout_ms = timeout::kInfinite,
+                            sigset_t* sigmask = nullptr) noexcept
+        : payload_ { &payload }
+        , timeout_ms_ { timeout_ms }
+        , sigmask_ { sigmask }
+    {
+    }
+
+    auto operator()(int fd) noexcept -> Result<std::size_t, std::error_code>
+    {
+        iovec iov = { payload_, sizeof(T) };
+        msghdr msg {};
+        msg.msg_iov = &iov;
+        msg.msg_iovlen = 1;
+
+        pollfd pfd {};
+        pfd.fd = fd;
+        if constexpr (std::is_same_v<Direction, decltype(io::read)>) {
+            pfd.events = POLLIN;
+        }
+        else {
+            pfd.events = POLLOUT;
+        }
+
+        timespec ts_storage = {};
+        timespec* ts = nullptr;
+        if (timeout_ms_ != timeout::kInfinite) {
+            ts_storage = { .tv_sec = static_cast<time_t>(timeout_ms_ / 1'000),
+                           .tv_nsec = static_cast<time_t>(
+                               (timeout_ms_ % 1'000) * 1'000'000) };
+            ts = &ts_storage;
+        }
+
+        /* NOTE:
+         * sigmask_ should be the *INVERSE* of the signals that we
+         * want to be notified on. E.g. if we're currently blocking
+         * SIGINT, and we wish for ppoll to tell us if a SIGINT
+         * occurred, then `sigmask_` *MUST NOT* contain SIGINT.
+         *
+         * Essentially, the current mask will be *SET* to `sigmask_`
+         * for the duration of `ppoll()`, and will be restored to
+         * its previous value after the call. If a signal occurs
+         * the `ppoll()` will return `EINTR`...
+         */
+        auto const poll_result = ::ppoll(&pfd, 1, ts, sigmask_);
+
+        if (poll_result < 0)
+            return result_error(
+                std::error_code { errno, std::system_category() });
+
+        if (poll_result == 0)
+            return result_ok(0ull);
+
+        auto const msg_result = handler_(fd, msg, *payload_);
+        if (msg_result < 0)
+            return result_error(
+                std::error_code { errno, std::system_category() });
+
+        return result_ok(static_cast<std::size_t>(msg_result));
+    }
+
+private:
+    Handler handler_ {};
+    T* payload_;
+    std::size_t timeout_ms_ { timeout::kInfinite };
+    sigset_t* sigmask_ { nullptr };
+};
+
+} // namespace sc
+
+#endif // SHADOW_CAST_IO_MESSAGE_HANDLER_HPP_INCLUDED

--- a/src/io/message_receiver.cpp
+++ b/src/io/message_receiver.cpp
@@ -1,0 +1,1 @@
+#include "io/message_receiver.hpp"

--- a/src/io/message_receiver.hpp
+++ b/src/io/message_receiver.hpp
@@ -1,0 +1,24 @@
+#ifndef SHADOW_CAST_IO_MESSAGE_RECEIVER_HPP_INCLUDED
+#define SHADOW_CAST_IO_MESSAGE_RECEIVER_HPP_INCLUDED
+
+#include "io/message_handler.hpp"
+
+namespace sc
+{
+
+template <typename T>
+struct ReceiveHandler
+{
+    auto operator()(int fd, msghdr& msg, T&) noexcept -> ssize_t
+    {
+        return ::recvmsg(fd, &msg, MSG_WAITALL);
+    }
+};
+
+template <typename T>
+using MessageReceiver =
+    MessageHandler<T, ReceiveHandler<T>, decltype(io::read)>;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_IO_MESSAGE_RECEIVER_HPP_INCLUDED

--- a/src/io/message_sender.cpp
+++ b/src/io/message_sender.cpp
@@ -1,0 +1,1 @@
+#include "io/message_sender.hpp"

--- a/src/io/message_sender.hpp
+++ b/src/io/message_sender.hpp
@@ -1,0 +1,22 @@
+#ifndef SHADOW_CAST_IO_MESSAGE_SENDER_HPP_INCLUDED
+#define SHADOW_CAST_IO_MESSAGE_SENDER_HPP_INCLUDED
+
+#include "io/message_handler.hpp"
+
+namespace sc
+{
+template <typename T>
+struct SendHandler
+{
+    auto operator()(int fd, msghdr const& msg, T const&) noexcept -> ssize_t
+    {
+        return ::sendmsg(fd, &msg, 0);
+    }
+};
+
+template <typename T>
+using MessageSender = MessageHandler<T, SendHandler<T>, decltype(io::write)>;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_IO_MESSAGE_SENDER_HPP_INCLUDED

--- a/src/io/process.cpp
+++ b/src/io/process.cpp
@@ -1,0 +1,86 @@
+#include "io/process.hpp"
+#include "utils/contracts.hpp"
+#include "utils/scope_guard.hpp"
+#include <algorithm>
+#include <cstring>
+#include <errno.h>
+#include <signal.h>
+#include <stdexcept>
+#include <sys/wait.h>
+#include <utility>
+#include <vector>
+
+using namespace std::literals::string_literals;
+
+namespace sc
+{
+Process::Process(pid_t pid) noexcept
+    : pid_ { pid }
+{
+}
+
+Process::Process(Process&& other) noexcept
+    : pid_ { std::exchange(other.pid_, -1) }
+{
+}
+
+Process::~Process() { SC_EXPECT(pid_ == -1); }
+
+auto Process::operator=(Process&& other) noexcept -> Process&
+{
+    using std::swap;
+
+    auto tmp { std::move(other) };
+    swap(*this, tmp);
+    return *this;
+}
+
+auto swap(Process& lhs, Process& rhs) noexcept -> void
+{
+    using std::swap;
+    swap(lhs.pid_, rhs.pid_);
+}
+
+auto Process::terminate() noexcept -> void { ::kill(pid_, SIGINT); }
+
+auto Process::wait() noexcept -> int
+{
+    SC_SCOPE_GUARD([&] { pid_ = -1; });
+    int wstatus;
+    ::waitpid(pid_, &wstatus, WEXITED);
+    if (!WIFEXITED(wstatus))
+        return 1;
+
+    return WEXITSTATUS(wstatus);
+}
+
+auto Process::terminate_and_wait() noexcept -> int
+{
+    terminate();
+    return wait();
+}
+
+auto spawn_process(std::span<std::string const> args) -> Process
+{
+    /* TODO:
+     */
+    std::vector<char const*> child_args(args.size() + 1, nullptr);
+    std::transform(args.begin(),
+                   args.end(),
+                   child_args.begin(),
+                   [](auto const& str) { return str.c_str(); });
+
+    auto pid = fork();
+    if (pid < 0)
+        throw std::runtime_error { "spawn_process failed: "s +
+                                   std::strerror(errno) };
+
+    if (pid == 0) {
+        ::execvp(child_args.front(),
+                 const_cast<char* const*>(child_args.data()));
+    }
+
+    return Process { pid };
+}
+
+} // namespace sc

--- a/src/io/process.hpp
+++ b/src/io/process.hpp
@@ -1,0 +1,35 @@
+#ifndef SHADOW_CAST_UTILS_PROCESS_HPP_INCLUDED
+#define SHADOW_CAST_UTILS_PROCESS_HPP_INCLUDED
+
+#include <span>
+#include <string>
+#include <unistd.h>
+
+namespace sc
+{
+
+struct Process
+{
+    friend auto spawn_process(std::span<std::string const> /*args*/) -> Process;
+    friend auto swap(Process&, Process&) noexcept -> void;
+
+    Process() noexcept = default;
+    Process(Process&&) noexcept;
+    ~Process();
+
+    auto operator=(Process&&) noexcept -> Process&;
+
+    auto terminate() noexcept -> void;
+    [[nodiscard]] auto wait() noexcept -> int;
+    [[nodiscard]] auto terminate_and_wait() noexcept -> int;
+
+private:
+    Process(pid_t /*pid*/) noexcept;
+    pid_t pid_ { -1 };
+};
+
+auto spawn_process(std::span<std::string const> /*args*/) -> Process;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_UTILS_PROCESS_HPP_INCLUDED

--- a/src/io/signals.cpp
+++ b/src/io/signals.cpp
@@ -1,0 +1,22 @@
+#include "io/signals.hpp"
+#include <signal.h>
+#include <system_error>
+
+namespace sc
+{
+
+auto block_signals(std::initializer_list<int> sigs) -> void
+{
+    sigset_t blocked_signals;
+    sigemptyset(&blocked_signals);
+    for (auto sig : sigs) {
+        if (auto const result = sigaddset(&blocked_signals, sig); result < 0)
+            throw std::system_error { errno, std::system_category() };
+    }
+    if (auto const result =
+            pthread_sigmask(SIG_SETMASK, &blocked_signals, nullptr);
+        result < 0)
+        throw std::system_error { errno, std::system_category() };
+}
+
+} // namespace sc

--- a/src/io/signals.hpp
+++ b/src/io/signals.hpp
@@ -1,0 +1,10 @@
+#ifndef SHADOW_CAST_IO_SIGNALS_HPP_INCLUDED
+#define SHADOW_CAST_IO_SIGNALS_HPP_INCLUDED
+
+#include <initializer_list>
+
+namespace sc
+{
+auto block_signals(std::initializer_list<int> /*sigs*/) -> void;
+} // namespace sc
+#endif // SHADOW_CAST_IO_SIGNALS_HPP_INCLUDED

--- a/src/io/unix_socket.cpp
+++ b/src/io/unix_socket.cpp
@@ -1,0 +1,120 @@
+#include "io/unix_socket.hpp"
+#include "utils/scope_guard.hpp"
+#include <algorithm>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdexcept>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <system_error>
+#include <unistd.h>
+#include <utility>
+
+using namespace std::literals::string_literals;
+
+namespace
+{
+
+template <typename F>
+auto create_socket(std::string_view path, F&& on_create)
+{
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0)
+        throw std::runtime_error { "connect(): "s + strerror(errno) };
+
+    auto close_guard = sc::ScopeGuard { [&] { close(fd); } };
+
+    sockaddr_un addr {};
+    addr.sun_family = AF_UNIX;
+    if (path.size() > std::size(addr.sun_path))
+        throw std::runtime_error { "create_socket(): path too long" };
+
+    auto&& result = on_create(fd, addr);
+    close_guard.deactivate();
+    return result;
+}
+
+} // namespace
+
+namespace sc
+{
+
+UnixSocket::UnixSocket(UnixSocket&& other) noexcept
+    : fd_ { std::exchange(other.fd_, -1) }
+{
+}
+
+UnixSocket::UnixSocket(int fd) noexcept
+    : fd_ { fd }
+{
+}
+
+UnixSocket::~UnixSocket() { close(); }
+
+auto UnixSocket::operator=(UnixSocket&& other) noexcept -> UnixSocket&
+{
+    using std::swap;
+    auto tmp { std::move(other) };
+
+    swap(*this, tmp);
+    return *this;
+}
+
+auto UnixSocket::close() noexcept -> int { return ::close(fd_); }
+
+auto UnixSocket::accept() -> UnixSocket
+{
+    sockaddr_un remote_addr;
+    socklen_t len = sizeof(sockaddr_un);
+    auto fd = ::accept(fd_, reinterpret_cast<sockaddr*>(&remote_addr), &len);
+    if (fd < 0)
+        throw std::runtime_error { "UnixSocket::accept() "s + strerror(errno) };
+
+    return UnixSocket { fd };
+}
+
+auto UnixSocket::listen() -> void
+{
+    if (auto const listen_result = ::listen(fd_, 1); listen_result < 0)
+        throw std::runtime_error { "UnixSocket::listen() "s + strerror(errno) };
+}
+
+auto UnixSocket::fd() const noexcept -> int { return fd_; }
+
+auto swap(UnixSocket& lhs, UnixSocket& rhs) noexcept -> void
+{
+    using std::swap;
+    swap(lhs.fd_, rhs.fd_);
+}
+
+namespace socket
+{
+
+auto bind(std::string_view path) -> UnixSocket
+{
+    return create_socket(path, [&](int fd, sockaddr_un addr) {
+        if (auto const result = bind(fd,
+                                     reinterpret_cast<sockaddr*>(&addr),
+                                     sizeof(addr.sun_family) + path.size());
+            result < 0)
+            throw std::logic_error { "bind(): "s + strerror(errno) };
+
+        return UnixSocket { fd };
+    });
+}
+
+auto connect(std::string_view path) -> UnixSocket
+{
+    return create_socket(path, [&](int fd, sockaddr_un addr) {
+        if (auto const result = connect(fd,
+                                        reinterpret_cast<sockaddr*>(&addr),
+                                        sizeof(addr.sun_family) + path.size());
+            result < 0)
+            throw std::logic_error { "connect(): "s + strerror(errno) };
+
+        return UnixSocket { fd };
+    });
+}
+
+} // namespace socket
+} // namespace sc

--- a/src/io/unix_socket.hpp
+++ b/src/io/unix_socket.hpp
@@ -1,0 +1,48 @@
+#ifndef SHADOW_CAST_IO_UNIX_SOCKET_HPP_INCLUDED
+#define SHADOW_CAST_IO_UNIX_SOCKET_HPP_INCLUDED
+
+#include <span>
+#include <string_view>
+
+namespace sc
+{
+struct UnixSocket;
+
+namespace socket
+{
+auto bind(std::string_view /*path*/) -> UnixSocket;
+auto connect(std::string_view /*path*/) -> UnixSocket;
+} // namespace socket
+
+struct UnixSocket
+{
+    friend auto swap(UnixSocket&, UnixSocket&) noexcept -> void;
+    friend auto socket::bind(std::string_view /*path*/) -> UnixSocket;
+    friend auto socket::connect(std::string_view /*path*/) -> UnixSocket;
+
+    UnixSocket() noexcept = default;
+    UnixSocket(UnixSocket&&) noexcept;
+    ~UnixSocket();
+
+    auto operator=(UnixSocket&&) noexcept -> UnixSocket&;
+
+    auto close() noexcept -> int;
+    auto accept() -> UnixSocket;
+    auto listen() -> void;
+    auto fd() const noexcept -> int;
+
+    template <typename F>
+    auto use_with(F&& f)
+    {
+        return std::forward<F>(f)(fd_);
+    }
+
+    UnixSocket(int /*fd*/) noexcept;
+
+    int fd_ { -1 };
+};
+
+auto swap(UnixSocket&, UnixSocket&) noexcept -> void;
+
+} // namespace sc
+#endif // SHADOW_CAST_IO_UNIX_SOCKET_HPP_INCLUDED

--- a/src/kms.cpp
+++ b/src/kms.cpp
@@ -1,0 +1,421 @@
+#include "drm.hpp"
+#include "io.hpp"
+#include "utils.hpp"
+
+#include <cinttypes>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <iostream>
+#include <libdrm/drm_mode.h>
+#include <linux/limits.h>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <system_error>
+#include <unistd.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+using IncomingMessage = sc::DRMRequest;
+using OutgoingMessage = sc::DRMResponse;
+
+auto constexpr kEnableLogging = false;
+
+struct NullLogger
+{
+};
+
+template <typename T>
+auto operator<<(NullLogger& logger, T const&) noexcept -> NullLogger&
+{
+    return logger;
+}
+
+auto null_logger() -> NullLogger&
+{
+    static NullLogger logger {};
+    return logger;
+}
+
+decltype(auto) log()
+{
+    if constexpr (kEnableLogging) {
+        return (std::cerr);
+    }
+    else {
+        return null_logger();
+    }
+}
+
+[[nodiscard]] auto is_drm_available() -> bool { return drmAvailable() == 1; }
+
+[[nodiscard]] auto get_drm_device_path() -> std::string
+{
+    int const max_devices = 10;
+    std::string device_path;
+    for (int i = 0; i < max_devices; ++i) {
+        char path[PATH_MAX];
+        if (auto const result =
+                std::snprintf(path, PATH_MAX, DRM_DEV_NAME, DRM_DIR_NAME, i);
+            result < 0 || result >= PATH_MAX)
+            throw std::runtime_error { "Failed to construct DRM device path" };
+
+        log() << "[DRM] Checking DRM path: " << path << '\n';
+
+        auto drm_fd = open(path, O_RDONLY);
+        if (drm_fd < 0)
+            continue;
+
+        SC_SCOPE_GUARD([&] { close(drm_fd); });
+
+        auto const ver = drmGetVersion(drm_fd);
+        if (!ver)
+            continue;
+
+        SC_SCOPE_GUARD([&] { drmFreeVersion(ver); });
+
+        std::string_view name { ver->name };
+        std::string_view desc { ver->desc };
+
+        log() << "[DRM] Found: " << name << ", " << desc << '\n';
+
+        auto const resources = drmModeGetResources(drm_fd);
+        if (!resources)
+            continue;
+
+        SC_SCOPE_GUARD([&] { drmModeFreeResources(resources); });
+
+        log() << "[DRM] count_fbs: " << resources->count_fbs << "\n";
+
+        drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+
+        auto const planes = drmModeGetPlaneResources(drm_fd);
+        if (!planes)
+            continue;
+
+        SC_SCOPE_GUARD([&] { drmModeFreePlaneResources(planes); });
+
+        for (uint32_t j = 0; j < planes->count_planes; ++j) {
+            auto const plane = drmModeGetPlane(drm_fd, planes->planes[j]);
+            if (!plane)
+                continue;
+
+            SC_SCOPE_GUARD([&] { drmModeFreePlane(plane); });
+
+            log() << "[DRM] Checking plane:\n"
+                  << "  plane_id: " << plane->plane_id << '\n'
+                  << "  count_formats: " << plane->count_formats << '\n'
+                  << "  fb_id: " << plane->fb_id << '\n'
+                  << "  crtc_id: " << plane->crtc_id << '\n'
+                  << "  crtc_x: " << plane->crtc_x
+                  << ", crtc_y: " << plane->crtc_y << '\n'
+                  << "  x: " << plane->x << ", y: " << plane->y << '\n';
+
+            if (plane->fb_id) {
+                log() << "[DRM] Found FB\n";
+                return path;
+            }
+            else
+                log() << "[DRM] No FB found in plane " << planes->planes[j]
+                      << '\n';
+        }
+    }
+
+    if (!device_path.size())
+        throw std::runtime_error { "Failed to find a valid DRM device path" };
+
+    return device_path;
+}
+
+auto get_connectors(int drm_fd)
+{
+    auto const resources = drmModeGetResources(drm_fd);
+    if (!resources)
+        throw std::runtime_error { "drmModeGetResources failed" };
+
+    SC_SCOPE_GUARD([&] { drmModeFreeResources(resources); });
+
+    for (auto i = 0; i < resources->count_connectors; ++i) {
+        auto const connector =
+            drmModeGetConnectorCurrent(drm_fd, resources->connectors[i]);
+        if (!connector)
+            continue;
+
+        SC_SCOPE_GUARD([&] { drmModeFreeConnector(connector); });
+
+        log() << "[DRM] Properties:\n";
+        for (auto j = 0; j < connector->count_props; ++j) {
+            auto const prop = drmModeGetProperty(drm_fd, connector->props[j]);
+            if (!prop)
+                continue;
+
+            SC_SCOPE_GUARD([&] { drmModeFreeProperty(prop); });
+            log() << "  " << prop->name << '\n';
+        }
+    }
+}
+
+auto get_plane_properties(int drm_fd,
+                          std::uint32_t plane_id,
+                          sc::PlaneDescriptor& descriptor)
+{
+    drmModeObjectPropertiesPtr props =
+        drmModeObjectGetProperties(drm_fd, plane_id, DRM_MODE_OBJECT_PLANE);
+    if (!props)
+        throw std::runtime_error { "drmModeObjectGetProperties failed" };
+
+    SC_SCOPE_GUARD([&] { drmModeFreeObjectProperties(props); });
+
+    log() << "[DRM] Plane properties:\n";
+
+    int x = 0;
+    int y = 0;
+
+    for (uint32_t i = 0; i < props->count_props; ++i) {
+        drmModePropertyPtr prop = drmModeGetProperty(drm_fd, props->props[i]);
+        if (!prop)
+            continue;
+
+        SC_SCOPE_GUARD([&] { drmModeFreeProperty(prop); });
+
+        std::string_view prop_name { prop->name };
+        log() << "[DRM] Property: " << prop_name
+              << ", Values: " << prop->count_values << '\n';
+
+        const uint32_t type = prop->flags & (DRM_MODE_PROP_LEGACY_TYPE |
+                                             DRM_MODE_PROP_EXTENDED_TYPE);
+
+        if ((type & DRM_MODE_PROP_SIGNED_RANGE) && prop_name == "CRTC_X") {
+            x = props->prop_values[i];
+        }
+        else if ((type & DRM_MODE_PROP_SIGNED_RANGE) && prop_name == "CRTC_Y") {
+            y = props->prop_values[i];
+        }
+        else if ((type & DRM_MODE_PROP_RANGE) && prop_name == "SRC_X") {
+            descriptor.x = (props->prop_values[i] >> 16);
+        }
+        else if ((type & DRM_MODE_PROP_RANGE) && prop_name == "SRC_Y") {
+            descriptor.y = (props->prop_values[i] >> 16);
+        }
+        else if ((type & DRM_MODE_PROP_RANGE) && prop_name == "SRC_W") {
+            descriptor.src_w = (props->prop_values[i] >> 16);
+        }
+        else if ((type & DRM_MODE_PROP_RANGE) && prop_name == "SRC_H") {
+            descriptor.src_h = (props->prop_values[i] >> 16);
+        }
+        else if ((type & DRM_MODE_PROP_ENUM) && prop_name == "type") {
+            const uint64_t current_enum_value = props->prop_values[i];
+            for (int j = 0; j < prop->count_enums; ++j) {
+                if (prop->enums[j].value == current_enum_value &&
+                    strcmp(prop->enums[j].name, "Cursor") == 0) {
+                    descriptor.set_flag(sc::plane_flags::IS_CURSOR);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (descriptor.is_flag_set(sc::plane_flags::IS_CURSOR)) {
+        descriptor.x = x;
+        descriptor.y = y;
+    }
+}
+
+auto get_fb(int drm_fd) -> OutgoingMessage
+{
+    auto const resources = drmModeGetPlaneResources(drm_fd);
+    if (!resources)
+        throw std::runtime_error { "drmModeGetPlaneResources failed" };
+
+    SC_SCOPE_GUARD([&] { drmModeFreePlaneResources(resources); });
+
+    OutgoingMessage msg {};
+
+    for (auto i = 0u;
+         i < resources->count_planes && i < sc::kMaxPlaneDescriptors;
+         ++i) {
+        auto const plane = drmModeGetPlane(drm_fd, resources->planes[i]);
+        SC_SCOPE_GUARD([&] {
+            if (plane)
+                drmModeFreePlane(plane);
+        });
+
+        if (!plane || !plane->fb_id)
+            continue;
+
+        log() << "[DRM] Got Plane\n";
+
+        /* Requires SYS_CAP_ADMIN from here, E.g...
+         *
+         *   $ setcap cap_sys_admin+ep <EXECUTABLE>
+         *
+         */
+        drmModeFB2Ptr const fb = drmModeGetFB2(drm_fd, plane->fb_id);
+        SC_SCOPE_GUARD([&] {
+            if (fb)
+                drmModeFreeFB2(fb);
+        });
+
+        if (!fb || !fb->handles[0])
+            throw std::runtime_error { "drmModeGetFB2 failed" };
+
+        int fb_fd = -1;
+        if (auto const result =
+                drmPrimeHandleToFD(drm_fd, fb->handles[0], O_RDONLY, &fb_fd);
+            result != 0 || fb_fd == -1)
+            throw std::runtime_error { "drmPrimeHandleToFD failed" };
+
+        SC_SCOPE_GUARD([&] {
+            for (auto h : fb->handles) {
+                if (!h)
+                    continue;
+
+                drmCloseBufferHandle(drm_fd, h);
+            }
+        });
+
+        msg.descriptors[i].fd = fb_fd;
+        msg.descriptors[i].width = fb->width;
+        msg.descriptors[i].height = fb->height;
+        msg.descriptors[i].pitch = fb->pitches[0];
+        msg.descriptors[i].offset = fb->offsets[0];
+        msg.descriptors[i].pixel_format = fb->pixel_format;
+        msg.descriptors[i].modifier = fb->modifier;
+
+        log() << "[DRM] Got FB FD: " << fb_fd << '\n';
+        log() << "[DRM] FB: " << fb->handles[0] << ' ' << fb->handles[1] << ' '
+              << fb->handles[2] << ' ' << fb->handles[3] << '\n';
+
+        msg.num_fds += 1;
+    }
+
+    return msg;
+}
+
+auto get_plane_descriptors(int drm_fd) -> OutgoingMessage
+{
+    return get_fb(drm_fd);
+}
+
+auto app(std::span<char const*> args) -> void
+{
+    sc::block_signals({ SIGINT });
+
+    if (!is_drm_available())
+        throw std::runtime_error { "DRM not available" };
+
+    auto const device_path = get_drm_device_path();
+
+    auto const drm_fd = open(device_path.c_str(), O_RDONLY);
+    if (drm_fd < 0)
+        throw std::runtime_error { "Failed to open DRM device" };
+
+    SC_SCOPE_GUARD([&] {
+        log() << "[DRM] Closing DRM FD...\n";
+        close(drm_fd);
+    });
+    if (auto const result =
+            drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
+        result != 0)
+        throw std::runtime_error { "drmSetClientCap failed" };
+
+    if (auto const result = drmSetClientCap(drm_fd, DRM_CLIENT_CAP_ATOMIC, 1);
+        result != 0)
+        throw std::runtime_error { "drmSetClientCap failed" };
+
+    /* We still need a sigaction so that the
+     * default SIGINT action isn't taken in
+     * when the `ppoll()` calls unblock it.
+     * We simply do a no-op...
+     */
+    auto ignore = [](int) {};
+    struct sigaction sa = {};
+    sa.sa_handler = ignore;
+    sigaction(SIGINT, &sa, nullptr);
+
+    /* This set of signals is what `ppoll()`
+     * will set the signal mask to when checking
+     * for events...
+     */
+    sigset_t emptysigset;
+    sigemptyset(&emptysigset);
+
+    log() << "[DRM] Connecting to: " << args[0] << '\n';
+
+    auto socket = sc::socket::connect(args[0]);
+
+    while (true) {
+        IncomingMessage req;
+        auto const receive_result =
+            socket.use_with(sc::MessageReceiver<IncomingMessage> {
+                req, sc::timeout::kInfinite, &emptysigset });
+
+        if (!receive_result) {
+            if (sc::get_error(receive_result).value() == EINTR)
+                break;
+
+            throw std::system_error { sc::get_error(receive_result) };
+        }
+
+        if (sc::get_value(receive_result) < sizeof(IncomingMessage))
+            break;
+
+        if (req.type == sc::drm_request::kStop)
+            break;
+
+        if (req.type != sc::drm_request::kGetPlanes) {
+            log() << "[DRM] Warning - ignoring unknown request type: "
+                  << req.type << '\n';
+            continue;
+        }
+
+        auto response = get_plane_descriptors(drm_fd);
+
+        SC_SCOPE_GUARD([&] {
+            log() << "[DRM] Closing " << response.num_fds << " fds\n";
+            for (auto i = 0u; i < response.num_fds; ++i)
+                close(response.descriptors[i].fd);
+        });
+
+        auto const send_result = socket.use_with(sc::DRMResponseSender {
+            response, sc::timeout::kInfinite, &emptysigset });
+
+        if (!send_result) {
+            log() << "[DRM] Failed to send: "
+                  << std::strerror(sc::get_error(send_result).value()) << '\n';
+            if (sc::get_error(send_result).value() == EINTR)
+                break;
+
+            throw std::system_error { sc::get_error(send_result) };
+        }
+
+        if (sc::get_value(send_result) < sizeof(response)) {
+            break;
+        }
+    }
+
+    log() << "[DRM] Stopping\n";
+}
+
+auto main(int argc, char const** argv) -> int
+{
+    try {
+        auto const args =
+            std::span { argv + 1, static_cast<std::size_t>(argc - 1) };
+        if (!args.size())
+            throw std::runtime_error { "Missing argument: socket path" };
+
+        app(args);
+    }
+    catch (std::exception const& e) {
+        log() << "ERROR: " << e.what() << '\n';
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/nvidia.hpp
+++ b/src/nvidia.hpp
@@ -6,10 +6,9 @@
 #include "./utils.hpp"
 #include "error.hpp"
 #include <array>
-#include <iostream>
+#include <cinttypes>
 #include <memory>
 #include <stdexcept>
-#include <cinttypes>
 
 namespace sc
 {

--- a/src/nvidia/cuda.hpp
+++ b/src/nvidia/cuda.hpp
@@ -72,6 +72,30 @@ struct CUDA_MEMCPY2D_st
     size_t Height;       /**< Height of 2D memory copy */
 };
 
+/**
+ * Array formats
+ */
+typedef enum CUarray_format_enum
+{
+    CU_AD_FORMAT_UNSIGNED_INT8 = 0x01,  /**< Unsigned 8-bit integers */
+    CU_AD_FORMAT_UNSIGNED_INT16 = 0x02, /**< Unsigned 16-bit integers */
+    CU_AD_FORMAT_UNSIGNED_INT32 = 0x03, /**< Unsigned 32-bit integers */
+    CU_AD_FORMAT_SIGNED_INT8 = 0x08,    /**< Signed 8-bit integers */
+    CU_AD_FORMAT_SIGNED_INT16 = 0x09,   /**< Signed 16-bit integers */
+    CU_AD_FORMAT_SIGNED_INT32 = 0x0a,   /**< Signed 32-bit integers */
+    CU_AD_FORMAT_HALF = 0x10,           /**< 16-bit floating point */
+    CU_AD_FORMAT_FLOAT = 0x20           /**< 32-bit floating point */
+} CUarray_format;
+
+typedef struct CUDA_ARRAY_DESCRIPTOR_st
+{
+    size_t Width;  /**< Width of array */
+    size_t Height; /**< Height of array */
+
+    CUarray_format Format;    /**< Array format */
+    unsigned int NumChannels; /**< Channels per array element */
+} CUDA_ARRAY_DESCRIPTOR;
+
 using CUDA_MEMCPY2D = CUDA_MEMCPY2D_st;
 using CUgraphicsResource = struct CUgraphicsResource_st*;
 
@@ -94,10 +118,6 @@ struct NvCuda
                               unsigned char uc,
                               std::size_t N);
     CUresult (*cuMemcpy2D_v2)(const CUDA_MEMCPY2D* pCopy);
-    CUresult (*cuGraphicsGLRegisterImage)(CUgraphicsResource* pCudaResource,
-                                          unsigned int image,
-                                          unsigned int target,
-                                          unsigned int flags);
     CUresult (*cuGraphicsEGLRegisterImage)(CUgraphicsResource* pCudaResource,
                                            void* image,
                                            unsigned int flags);
@@ -114,6 +134,8 @@ struct NvCuda
                                                     CUgraphicsResource resource,
                                                     unsigned int arrayIndex,
                                                     unsigned int mipLevel);
+    CUresult (*cuArrayGetDescriptor_v2)(CUDA_ARRAY_DESCRIPTOR* pArrayDescriptor,
+                                        CUarray hArray);
 };
 
 struct NvCudaError : std::runtime_error

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -1,0 +1,7 @@
+#ifndef SHADOW_CAST_PLATFORM_HPP_INCLUDED
+#define SHADOW_CAST_PLATFORM_HPP_INCLUDED
+
+#include "./platform/egl.hpp"
+#include "./platform/wayland.hpp"
+
+#endif // SHADOW_CAST_PLATFORM_HPP_INCLUDED

--- a/src/platform/egl.cpp
+++ b/src/platform/egl.cpp
@@ -1,0 +1,39 @@
+#include "platform/egl.hpp"
+#include "error.hpp"
+#include "utils/symbol.hpp"
+
+namespace sc
+{
+
+auto load_egl() -> EGL
+{
+    auto lib = dlopen("libEGL.so.1", RTLD_LAZY);
+    if (!lib)
+        throw ModuleError { std::string { "Couldn't load libEGL.so.1: " } +
+                            dlerror() };
+
+    EGL egl {};
+    TRY_ATTACH_SYMBOL(&egl.eglCreateImage, "eglCreateImage", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglDestroyImage, "eglDestroyImage", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglGetError, "eglGetError", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglSwapInterval, "eglSwapInterval", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglGetDisplay, "eglGetDisplay", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglGetPlatformDisplay, "eglGetPlatformDisplay", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglInitialize, "eglInitialize", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglTerminate, "eglTerminate", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglBindAPI, "eglBindAPI", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglChooseConfig, "eglChooseConfig", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglCreateContext, "eglCreateContext", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglDestroyContext, "eglDestroyContext", lib);
+    TRY_ATTACH_SYMBOL(
+        &egl.eglCreateWindowSurface, "eglCreateWindowSurface", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglDestroySurface, "eglDestroySurface", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglQueryString, "eglQueryString", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglGetProcAddress, "eglGetProcAddress", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglMakeCurrent, "eglMakeCurrent", lib);
+    TRY_ATTACH_SYMBOL(&egl.eglSwapBuffers, "eglSwapBuffers", lib);
+
+    return egl;
+}
+
+} // namespace sc

--- a/src/platform/egl.hpp
+++ b/src/platform/egl.hpp
@@ -1,0 +1,70 @@
+#ifndef SHADOW_CAST_EGL_HPP_INCLUDED
+#define SHADOW_CAST_EGL_HPP_INCLUDED
+
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
+namespace sc
+{
+
+struct EGL
+{
+    EGLImage (*eglCreateImage)(EGLDisplay dpy,
+                               EGLContext ctx,
+                               unsigned int target,
+                               EGLClientBuffer buffer,
+                               const intptr_t* attrib_list);
+
+    unsigned int (*eglDestroyImage)(EGLDisplay dpy, EGLImage image);
+
+    unsigned int (*eglGetError)(void);
+
+    unsigned int (*eglSwapInterval)(EGLDisplay dpy, int32_t interval);
+
+    EGLDisplay (*eglGetDisplay)(EGLNativeDisplayType display_id);
+    EGLDisplay (*eglGetPlatformDisplay)(EGLenum platfor,
+                                        void* native_display,
+                                        EGLAttrib const* attrib_list);
+
+    unsigned int (*eglInitialize)(EGLDisplay dpy,
+                                  int32_t* major,
+                                  int32_t* minor);
+
+    unsigned int (*eglTerminate)(EGLDisplay dpy);
+
+    unsigned int (*eglBindAPI)(unsigned int api);
+
+    unsigned int (*eglChooseConfig)(EGLDisplay dpy,
+                                    const int32_t* attrib_list,
+                                    EGLConfig* configs,
+                                    int32_t config_size,
+                                    int32_t* num_config);
+
+    EGLContext (*eglCreateContext)(EGLDisplay dpy,
+                                   EGLConfig config,
+                                   EGLContext share_context,
+                                   const int32_t* attrib_list);
+
+    unsigned int (*eglDestroyContext)(EGLDisplay dpy, EGLContext ctx);
+
+    EGLSurface (*eglCreateWindowSurface)(EGLDisplay dpy,
+                                         EGLConfig config,
+                                         EGLNativeWindowType win,
+                                         const int32_t* attrib_list);
+
+    EGLSurface (*eglSwapBuffers)(EGLDisplay dpy, EGLSurface draw);
+    unsigned int (*eglDestroySurface)(EGLDisplay dpy, EGLSurface ctx);
+
+    char const* (*eglQueryString)(EGLDisplay dpy, EGLint name);
+    void* (*eglGetProcAddress)(char const* name);
+    unsigned int (*eglMakeCurrent)(EGLDisplay dpy,
+                                   EGLSurface draw,
+                                   EGLSurface read,
+                                   EGLContext ctx);
+};
+
+auto load_egl() -> EGL;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_EGL_HPP_INCLUDED

--- a/src/platform/wayland.cpp
+++ b/src/platform/wayland.cpp
@@ -1,0 +1,260 @@
+#include "platform/wayland.hpp"
+#include "utils/contracts.hpp"
+#include "utils/scope_guard.hpp"
+#include <EGL/eglext.h>
+#include <cinttypes>
+#include <string_view>
+
+namespace
+{
+
+wl_output_listener const output_listener = {
+    .geometry = [](void* /*data*/,
+                   struct wl_output* /*wl_output*/,
+                   int32_t /*x*/,
+                   int32_t /*y*/,
+                   int32_t /*physical_width*/,
+                   int32_t /*physical_height*/,
+                   int32_t /*subpixel*/,
+                   const char* /*make*/,
+                   const char* /*model*/,
+                   int32_t /*transform*/) {},
+
+    .mode =
+        [](void* data,
+           struct wl_output* /*output*/,
+           uint32_t flags,
+           int32_t width,
+           int32_t height,
+           int32_t /*refresh*/) {
+            if ((flags & WL_OUTPUT_MODE_CURRENT) == 0)
+                return;
+
+            auto& platform = *reinterpret_cast<sc::Wayland*>(data);
+            platform.output_width = width;
+            platform.output_height = height;
+        },
+
+    .done = [](void* /*data*/, struct wl_output* /*wl_output*/) {},
+
+    .scale = [](void* /*data*/,
+                struct wl_output* /*wl_output*/,
+                int32_t /*factor*/) {},
+
+    .name = [](void* /*data*/,
+               struct wl_output* /*wl_output*/,
+               const char* /*name*/) {},
+
+    .description = [](void* /*data*/,
+                      struct wl_output* /*wl_output*/,
+                      const char* /*description*/) {},
+};
+
+wl_registry_listener const registry_listener = {
+    .global =
+        [](void* data,
+           wl_registry* registry,
+           std::uint32_t name,
+           char const* iface,
+           std::uint32_t version) {
+            auto* platform = reinterpret_cast<sc::Wayland*>(data);
+            std::string_view interface = iface;
+
+            if (interface == wl_compositor_interface.name) {
+                platform->compositor.reset(
+                    reinterpret_cast<wl_compositor*>(wl_registry_bind(
+                        registry, name, &wl_compositor_interface, version)));
+            }
+            else if (interface == wl_output_interface.name) {
+                platform->output.reset(
+                    reinterpret_cast<wl_output*>(wl_registry_bind(
+                        registry, name, &wl_output_interface, version)));
+
+                wl_output_add_listener(
+                    platform->output.get(), &output_listener, platform);
+            }
+        },
+    .global_remove = [](void* /*data*/,
+                        wl_registry* /*registry*/,
+                        std::uint32_t /*name*/) {},
+};
+
+} // namespace
+
+namespace sc
+{
+
+namespace wayland
+{
+
+auto DisplayDeleter::operator()(wl_display* ptr) const noexcept -> void
+{
+    wl_display_disconnect(ptr);
+}
+
+auto RegistryDeleter::operator()(wl_registry* ptr) const noexcept -> void
+{
+    wl_registry_destroy(ptr);
+}
+
+auto CompositorDeleter::operator()(wl_compositor* ptr) const noexcept -> void
+{
+    wl_compositor_destroy(ptr);
+}
+
+auto SurfaceDeleter::operator()(wl_surface* ptr) const noexcept -> void
+{
+    wl_surface_destroy(ptr);
+}
+
+auto WindowDeleter::operator()(wl_egl_window* ptr) const noexcept -> void
+{
+    wl_egl_window_destroy(ptr);
+}
+
+auto OutputDeleter::operator()(wl_output* ptr) const noexcept -> void
+{
+    wl_output_release(ptr);
+}
+
+} // namespace wayland
+
+namespace egl
+{
+
+EGLDeleter::EGLDeleter(EGL e, EGLDisplay d) noexcept
+    : egl { e }
+    , display { d }
+{
+}
+
+auto EGLDisplayDeleter::operator()(EGLDisplay ptr) const noexcept -> void
+{
+    egl.eglTerminate(ptr);
+}
+
+auto EGLContextDeleter::operator()(EGLContext ptr) const noexcept -> void
+{
+    egl.eglDestroyContext(display, ptr);
+}
+
+auto EGLSurfaceDeleter::operator()(EGLSurface ptr) const noexcept -> void
+{
+    egl.eglDestroySurface(display, ptr);
+}
+
+} // namespace egl
+
+auto initialize_wayland(wayland::DisplayPtr display) -> std::unique_ptr<Wayland>
+{
+    auto platform = std::make_unique<Wayland>();
+
+    platform->display = std::move(display);
+    if (!platform->display)
+        throw std::runtime_error { "Failed to connect to Wayland display" };
+
+    platform->registry.reset(wl_display_get_registry(platform->display.get()));
+    if (!platform->registry)
+        throw std::runtime_error { "Failed to get Wayland registry" };
+
+    SC_SCOPE_GUARD([&] { platform->registry.reset(nullptr); });
+
+    wl_registry_add_listener(
+        platform->registry.get(), &registry_listener, platform.get());
+
+    wl_display_roundtrip(platform->display.get());
+
+    wl_display_roundtrip(platform->display.get());
+
+    SC_EXPECT(platform->output_width);
+    SC_EXPECT(platform->output_height);
+
+    SC_SCOPE_GUARD([&] { platform->output.reset(nullptr); });
+
+    if (!platform->compositor)
+        throw std::runtime_error { "Failed to get Wayland compositor" };
+
+    platform->surface.reset(
+        wl_compositor_create_surface(platform->compositor.get()));
+    if (!platform->surface)
+        throw std::runtime_error { "Failed to create Wayland surface" };
+
+    platform->window.reset(
+        wl_egl_window_create(platform->surface.get(), 16, 16));
+    if (!platform->window)
+        throw std::runtime_error { "Failed to create Wayland window" };
+
+    return platform;
+}
+
+auto initialize_wayland_egl(EGL egl, Wayland const& platform) -> WaylandEGL
+{
+    // clang-format off
+    const int32_t attr[] = {
+        EGL_BUFFER_SIZE, 24,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_NONE,
+    };
+
+    const int32_t ctxattr[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_CONTEXT_PRIORITY_LEVEL_IMG, EGL_CONTEXT_PRIORITY_HIGH_IMG, /* requires cap_sys_nice, ignored
+                                          otherwise */
+        EGL_NONE,
+    };
+    // clang-format on
+
+    if (!egl.eglBindAPI(EGL_OPENGL_API))
+        throw std::runtime_error { "Failed to bind EGL API" };
+
+    egl::EGLDisplayPtr egl_display { egl.eglGetDisplay(platform.display.get()),
+                                     { egl } };
+
+    if (!egl_display)
+        throw std::runtime_error { "Failed to get EGL display" };
+
+    if (!egl.eglInitialize(egl_display.get(), nullptr, nullptr)) {
+        egl_display.release();
+        throw std::runtime_error { "Failed to initialize EGL display" };
+    }
+
+    EGLConfig egl_config;
+    std::int32_t num_egl_config = 0;
+    if (!egl.eglChooseConfig(
+            egl_display.get(), attr, &egl_config, 1, &num_egl_config)) {
+        throw std::runtime_error { "Failed to select EGL config" };
+    }
+
+    egl::EGLSurfacePtr egl_surface { egl.eglCreateWindowSurface(
+                                         egl_display.get(),
+                                         egl_config,
+                                         reinterpret_cast<EGLNativeWindowType>(
+                                             platform.window.get()),
+                                         nullptr),
+                                     { egl, egl_display.get() } };
+
+    if (!egl_surface)
+        throw std::runtime_error { "Failed to create EGL surface" };
+
+    egl::EGLContextPtr egl_context {
+        egl.eglCreateContext(egl_display.get(), egl_config, nullptr, ctxattr),
+        { egl, egl_display.get() }
+    };
+
+    if (!egl_context)
+        throw std::runtime_error { "Failed to create EGL context" };
+
+    if (!egl.eglMakeCurrent(egl_display.get(),
+                            egl_surface.get(),
+                            egl_surface.get(),
+                            egl_context.get()))
+        throw std::runtime_error { "Couldn't select context" };
+
+    return {
+        .egl_display = std::move(egl_display),
+        .egl_surface = std::move(egl_surface),
+        .egl_context = std::move(egl_context),
+    };
+}
+
+} // namespace sc

--- a/src/platform/wayland.hpp
+++ b/src/platform/wayland.hpp
@@ -1,0 +1,125 @@
+#ifndef SHADOW_CAST_PLATFORM_WAYLAND_HPP_INCLUDED
+#define SHADOW_CAST_PLATFORM_WAYLAND_HPP_INCLUDED
+
+#include "./egl.hpp"
+#include <memory>
+#include <type_traits>
+#include <wayland-client.h>
+#include <wayland-egl.h>
+
+namespace sc
+{
+
+namespace wayland
+{
+
+struct DisplayDeleter
+{
+    auto operator()(wl_display* ptr) const noexcept -> void;
+};
+
+using DisplayPtr = std::unique_ptr<wl_display, DisplayDeleter>;
+
+struct RegistryDeleter
+{
+    auto operator()(wl_registry* ptr) const noexcept -> void;
+};
+
+using RegistryPtr = std::unique_ptr<wl_registry, RegistryDeleter>;
+
+struct CompositorDeleter
+{
+    auto operator()(wl_compositor* ptr) const noexcept -> void;
+};
+
+using CompositorPtr = std::unique_ptr<wl_compositor, CompositorDeleter>;
+
+struct SurfaceDeleter
+{
+    auto operator()(wl_surface* ptr) const noexcept -> void;
+};
+
+using SurfacePtr = std::unique_ptr<wl_surface, SurfaceDeleter>;
+
+struct WindowDeleter
+{
+    auto operator()(wl_egl_window* ptr) const noexcept -> void;
+};
+
+using WindowPtr = std::unique_ptr<wl_egl_window, WindowDeleter>;
+
+struct OutputDeleter
+{
+    auto operator()(wl_output* ptr) const noexcept -> void;
+};
+
+using OutputPtr = std::unique_ptr<wl_output, OutputDeleter>;
+
+} // namespace wayland
+
+namespace egl
+{
+struct EGLDeleter
+{
+    EGLDeleter(EGL e, EGLDisplay d) noexcept;
+    EGL egl;
+    EGLDisplay display;
+};
+
+struct EGLDisplayDeleter
+{
+    auto operator()(EGLDisplay ptr) const noexcept -> void;
+    EGL egl;
+};
+
+using EGLDisplayPtr =
+    std::unique_ptr<std::remove_pointer_t<EGLDisplay>, EGLDisplayDeleter>;
+
+struct EGLContextDeleter : EGLDeleter
+{
+    using EGLDeleter::EGLDeleter;
+
+    auto operator()(EGLContext ptr) const noexcept -> void;
+};
+
+using EGLContextPtr =
+    std::unique_ptr<std::remove_pointer_t<EGLContext>, EGLContextDeleter>;
+
+struct EGLSurfaceDeleter : EGLDeleter
+{
+    using EGLDeleter::EGLDeleter;
+
+    auto operator()(EGLSurface ptr) const noexcept -> void;
+};
+
+using EGLSurfacePtr =
+    std::unique_ptr<std::remove_pointer_t<EGLSurface>, EGLSurfaceDeleter>;
+
+} // namespace egl
+
+struct Wayland
+{
+    wayland::DisplayPtr display;
+    wayland::RegistryPtr registry;
+    wayland::OutputPtr output;
+    wayland::CompositorPtr compositor;
+    wayland::SurfacePtr surface;
+    wayland::WindowPtr window;
+
+    std::uint32_t output_width { 0 };
+    std::uint32_t output_height { 0 };
+};
+
+struct WaylandEGL
+{
+    egl::EGLDisplayPtr egl_display;
+    egl::EGLSurfacePtr egl_surface;
+    egl::EGLContextPtr egl_context;
+};
+
+auto initialize_wayland(wayland::DisplayPtr) -> std::unique_ptr<Wayland>;
+auto initialize_wayland_egl(EGL, Wayland const&) -> WaylandEGL;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_PLATFORM_WAYLAND_HPP_INCLUDED

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -3,6 +3,7 @@
 
 #include "./services/audio_service.hpp"
 #include "./services/context.hpp"
+#include "./services/drm_video_service.hpp"
 #include "./services/service.hpp"
 #include "./services/service_registry.hpp"
 #include "./services/signal_service.hpp"

--- a/src/services/audio_service.cpp
+++ b/src/services/audio_service.cpp
@@ -286,7 +286,7 @@ auto AudioService::on_init(ReadinessRegister reg) -> void
     start_pipewire(loop_data_);
 }
 
-auto AudioService::on_uninit() -> void
+auto AudioService::on_uninit() noexcept -> void
 {
     stop_pipewire(loop_data_);
 

--- a/src/services/audio_service.hpp
+++ b/src/services/audio_service.hpp
@@ -54,7 +54,7 @@ struct AudioService final : Service
 
 protected:
     auto on_init(ReadinessRegister) -> void override;
-    auto on_uninit() -> void override;
+    auto on_uninit() noexcept -> void override;
 
 public:
     template <typename F>

--- a/src/services/context.cpp
+++ b/src/services/context.cpp
@@ -5,7 +5,6 @@
 #include <cassert>
 #include <cstddef>
 #include <errno.h>
-#include <iostream>
 #include <limits>
 #include <poll.h>
 #include <signal.h>

--- a/src/services/drm_video_service.cpp
+++ b/src/services/drm_video_service.cpp
@@ -1,0 +1,249 @@
+#include "services/drm_video_service.hpp"
+#include "drm.hpp"
+#include "io/accept_handler.hpp"
+#include "io/message_receiver.hpp"
+#include "io/message_sender.hpp"
+#include "utils/result.hpp"
+#include "utils/scope_guard.hpp"
+#include <algorithm>
+#include <libdrm/drm_fourcc.h>
+#include <system_error>
+#include <vector>
+
+namespace
+{
+char constexpr kSocketPath[] = "/tmp/shadow-cast.sock";
+std::size_t constexpr kDRMConnectTimeoutMs = 1'000;
+std::size_t constexpr kDRMDataTimeoutMs = 1'000;
+char constexpr kDRMBin[] = "shadow-cast-kms";
+
+auto get_drm_data(sc::UnixSocket& socket, std::size_t timeout, sigset_t* mask)
+    -> sc::Result<sc::DRMResponse, std::error_code>
+{
+    sc::DRMRequest request { sc::drm_request::kGetPlanes };
+    sc::DRMResponse response {};
+
+    auto const send_result = socket.use_with(
+        sc::MessageSender<sc::DRMRequest> { request, timeout, mask });
+
+    if (!send_result) {
+        return send_result.error();
+    }
+
+    if (sc::get_value(send_result) < sizeof(request)) {
+        return sc::result_error(
+            std::error_code { EAGAIN, std::system_category() });
+    }
+
+    auto const recv_result =
+        socket.use_with(sc::DRMResponseReceiver { response, timeout, mask });
+
+    if (!recv_result) {
+        return recv_result.error();
+    }
+
+    if (sc::get_value(recv_result) < sizeof(response)) {
+        return sc::result_error(
+            std::error_code { EAGAIN, std::system_category() });
+    }
+
+    return sc::result_ok(response);
+}
+
+auto register_egl_image_in_cuda(sc::NvCuda const& nvcuda,
+                                CUcontext ctx,
+                                EGLImage egl_image,
+                                CUgraphicsResource& cuda_gfx_resource,
+                                CUarray& cuda_array) -> void
+{
+    using namespace std::literals::string_literals;
+
+    char const* err_str = "unknown";
+
+    CUcontext old_ctx;
+    /*CUresult res = */ nvcuda.cuCtxPushCurrent_v2(ctx);
+    SC_SCOPE_GUARD([&] { nvcuda.cuCtxPopCurrent_v2(&old_ctx); });
+
+    if (auto const r = nvcuda.cuGraphicsEGLRegisterImage(
+            &cuda_gfx_resource,
+            egl_image,
+            CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY);
+        r != CUDA_SUCCESS) {
+        nvcuda.cuGetErrorString(r, &err_str);
+        throw std::runtime_error {
+            "CUDA: Failed to register image with CUDA - "s + err_str
+        };
+    }
+
+    if (auto const r = nvcuda.cuGraphicsResourceSetMapFlags(
+            cuda_gfx_resource, CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY);
+        r != CUDA_SUCCESS) {
+        nvcuda.cuGetErrorString(r, &err_str);
+        throw std::runtime_error { "CUDA: Failed to set map flags - "s +
+                                   err_str };
+    }
+
+    if (auto const r = nvcuda.cuGraphicsSubResourceGetMappedArray(
+            &cuda_array, cuda_gfx_resource, 0, 0);
+        r != CUDA_SUCCESS) {
+        nvcuda.cuGetErrorString(r, &err_str);
+        throw std::runtime_error { "CUDA: Failed to get mapped array - "s +
+                                   err_str };
+    }
+}
+
+} // namespace
+
+namespace sc
+{
+
+DRMVideoService::DRMVideoService(NvCuda nvcuda,
+                                 CUcontext cuda_ctx,
+                                 EGL& egl,
+                                 Wayland& wayland,
+                                 WaylandEGL& plaform_egl) noexcept
+    : nvcuda_ { nvcuda }
+    , cuda_ctx_ { cuda_ctx }
+    , egl_ { &egl }
+    , wayland_ { &wayland }
+    , platform_egl_ { &plaform_egl }
+{
+}
+
+auto DRMVideoService::on_init(ReadinessRegister reg) -> void
+{
+    /* SIGCHLD should be blocked before `on_init()` is
+     * called...
+     */
+    sigemptyset(&drm_proc_mask_);
+    sigaddset(&drm_proc_mask_, SIGCHLD);
+
+    auto server_socket = sc::socket::bind(kSocketPath);
+
+    /* We don't need the listening socket outside
+     * of this function; The child process either
+     * connects successfully, in which case we don't
+     * accept any more connections, or it fails
+     * to connect and we can't proceed anyway...
+     */
+    SC_SCOPE_GUARD([&] {
+        server_socket.close();
+        unlink(kSocketPath);
+    });
+
+    server_socket.listen();
+
+    /* Spawn the DRM child process and wait for it
+     * to attach itself...
+     */
+    std::vector<std::string> args { kDRMBin, kSocketPath };
+    drm_process_ = sc::spawn_process(std::span { args.data(), args.size() });
+    auto socket_result = server_socket.use_with(
+        sc::AcceptHandler { kDRMConnectTimeoutMs, &drm_proc_mask_ });
+
+    if (!socket_result)
+        throw std::system_error { sc::get_error(socket_result) };
+
+    drm_socket_ = UnixSocket { sc::get_value(socket_result) };
+
+    egl_->eglSwapInterval(platform_egl_->egl_display.get(), 0);
+
+    reg(FrameTimeRatio(1), &dispatch_frame);
+}
+
+auto DRMVideoService::on_uninit() noexcept -> void
+{
+    static_cast<void>(drm_process_.terminate_and_wait());
+    drm_socket_.close();
+}
+
+auto DRMVideoService::dispatch_frame(Service& svc) -> void
+{
+    auto& self = static_cast<DRMVideoService&>(svc);
+    if (!self.frame_handler_)
+        return;
+
+    auto const r =
+        get_drm_data(self.drm_socket_, kDRMDataTimeoutMs, &self.drm_proc_mask_);
+
+    if (!r) {
+        if (sc::get_error(r).value() == EINTR)
+            return;
+
+        throw std::system_error { r.error() };
+    }
+
+    auto const drm_data = sc::get_value(r);
+
+    if (!drm_data.num_fds)
+        throw std::runtime_error { "No DRM planes received" };
+
+    SC_SCOPE_GUARD([&] {
+        /* If we received any dma-buf fds then it is
+         * our responsibility to close them...
+         */
+        for (decltype(drm_data.num_fds) i = 0; i < drm_data.num_fds; ++i)
+            ::close(drm_data.descriptors[i].fd);
+    });
+
+    auto const& descriptor = std::max_element(
+        std::begin(drm_data.descriptors),
+        std::next(std::begin(drm_data.descriptors), drm_data.num_fds),
+        [](auto const& a, auto const& b) {
+            return (a.width * a.height) < (b.width * b.height);
+        });
+
+    // clang-format off
+    const std::intptr_t img_attr[] = {
+        EGL_LINUX_DRM_FOURCC_EXT, DRM_FORMAT_ARGB8888 /*descriptor.pixel_format*/,
+        EGL_WIDTH, descriptor->width,
+        EGL_HEIGHT, descriptor->height,
+        EGL_DMA_BUF_PLANE0_FD_EXT, descriptor->fd,
+        EGL_DMA_BUF_PLANE0_OFFSET_EXT, descriptor->offset,
+        EGL_DMA_BUF_PLANE0_PITCH_EXT, descriptor->pitch,
+        EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT, static_cast<std::uint32_t>(descriptor->modifier & 0xffffffffull),
+        EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT, static_cast<std::uint32_t>(descriptor->modifier >> 32ull),
+        EGL_NONE
+    };
+    // clang-format on
+
+    EGLImage image =
+        self.egl_->eglCreateImage(self.platform_egl_->egl_display.get(),
+                                  EGL_NO_CONTEXT,
+                                  EGL_LINUX_DMA_BUF_EXT,
+                                  static_cast<EGLClientBuffer>(nullptr),
+                                  img_attr);
+
+    if (image == EGL_NO_IMAGE) {
+        throw std::runtime_error { "eglCreateImage failed: " +
+                                   std::to_string(self.egl_->eglGetError()) };
+    }
+
+    SC_SCOPE_GUARD([&] {
+        self.egl_->eglDestroyImage(self.platform_egl_->egl_display.get(),
+                                   image);
+    });
+
+    register_egl_image_in_cuda(self.nvcuda_,            /* in */
+                               self.cuda_ctx_,          /* in */
+                               image,                   /* in */
+                               self.cuda_gfx_resource_, /* out */
+                               self.cuda_array_);       /* out */
+
+    SC_SCOPE_GUARD([&] {
+        CUcontext old_ctx;
+        self.nvcuda_.cuCtxPushCurrent_v2(self.cuda_ctx_);
+        SC_SCOPE_GUARD([&] { self.nvcuda_.cuCtxPopCurrent_v2(&old_ctx); });
+
+        if (self.cuda_gfx_resource_) {
+            self.nvcuda_.cuGraphicsUnmapResources(
+                1, &self.cuda_gfx_resource_, 0);
+            self.nvcuda_.cuGraphicsUnregisterResource(self.cuda_gfx_resource_);
+            self.cuda_gfx_resource_ = nullptr;
+        }
+    });
+
+    (*self.frame_handler_)(self.cuda_array_, self.nvcuda_);
+}
+
+} // namespace sc

--- a/src/services/drm_video_service.hpp
+++ b/src/services/drm_video_service.hpp
@@ -1,0 +1,59 @@
+#ifndef SHADOW_CAST_SERVICES_DRM_VIDEO_SERVICE_HPP_INCLUDED
+#define SHADOW_CAST_SERVICES_DRM_VIDEO_SERVICE_HPP_INCLUDED
+
+#include "drm/messaging.hpp"
+#include "io/process.hpp"
+#include "io/unix_socket.hpp"
+#include "nvidia.hpp"
+#include "platform/egl.hpp"
+#include "platform/wayland.hpp"
+#include "services/readiness.hpp"
+#include "services/service.hpp"
+#include "utils/borrowed_ptr.hpp"
+#include "utils/receiver.hpp"
+#include <optional>
+#include <signal.h>
+
+namespace sc
+{
+
+struct DRMVideoService final : Service
+{
+    using CaptureFrameReceiverType = Receiver<void(CUarray, NvCuda const&)>;
+
+    explicit DRMVideoService(NvCuda nvcuda,
+                             CUcontext cuda_ctx,
+                             EGL& egl,
+                             Wayland& wayland,
+                             WaylandEGL& platform_egl) noexcept;
+
+    template <typename F>
+    auto set_capture_frame_handler(F&& handler) -> void
+    {
+        frame_handler_ = CaptureFrameReceiverType { std::forward<F>(handler) };
+    }
+
+protected:
+    auto on_init(ReadinessRegister) -> void override;
+    auto on_uninit() noexcept -> void override;
+
+private:
+    static auto dispatch_frame(Service&) -> void;
+
+private:
+    NvCuda nvcuda_;
+    CUcontext cuda_ctx_;
+    BorrowedPtr<EGL> egl_;
+    BorrowedPtr<Wayland> wayland_;
+    BorrowedPtr<WaylandEGL> platform_egl_;
+    UnixSocket drm_socket_;
+    Process drm_process_;
+    sigset_t drm_proc_mask_;
+    std::optional<CaptureFrameReceiverType> frame_handler_;
+    CUgraphicsResource cuda_gfx_resource_ { nullptr };
+    CUarray cuda_array_ { nullptr };
+};
+
+} // namespace sc
+
+#endif // SHADOW_CAST_SERVICES_DRM_VIDEO_SERVICE_HPP_INCLUDED

--- a/src/services/service.cpp
+++ b/src/services/service.cpp
@@ -10,8 +10,8 @@ auto Service::init(ReadinessRegister register_readiness) -> void
     on_init(register_readiness);
 }
 
-auto Service::uninit() -> void { on_uninit(); }
+auto Service::uninit() noexcept -> void { on_uninit(); }
 
-auto Service::on_uninit() -> void {}
+auto Service::on_uninit() noexcept -> void {}
 
 } // namespace sc

--- a/src/services/service.hpp
+++ b/src/services/service.hpp
@@ -16,11 +16,11 @@ struct Service
 {
     virtual ~Service();
     auto init(ReadinessRegister) -> void;
-    auto uninit() -> void;
+    auto uninit() noexcept -> void;
 
 protected:
     virtual auto on_init(ReadinessRegister) -> void = 0;
-    virtual auto on_uninit() -> void;
+    virtual auto on_uninit() noexcept -> void;
 };
 
 } // namespace sc

--- a/src/services/signal_service.cpp
+++ b/src/services/signal_service.cpp
@@ -39,7 +39,7 @@ auto SignalService::on_init(ReadinessRegister reg) -> void
     reg(notify_fd_, &dispatch_signal);
 }
 
-auto SignalService::on_uninit() -> void
+auto SignalService::on_uninit() noexcept -> void
 {
     pthread_sigmask(SIG_SETMASK, &original_mask_, nullptr);
 }

--- a/src/services/signal_service.hpp
+++ b/src/services/signal_service.hpp
@@ -42,7 +42,7 @@ struct SignalService final : Service
 
 protected:
     auto on_init(ReadinessRegister) -> void override;
-    auto on_uninit() -> void override;
+    auto on_uninit() noexcept -> void override;
 
 private:
     sigset_t original_mask_;

--- a/src/shadow_cast.hpp
+++ b/src/shadow_cast.hpp
@@ -5,7 +5,9 @@
 #include "./display.hpp"
 #include "./error.hpp"
 #include "./handlers.hpp"
+#include "./io.hpp"
 #include "./nvidia.hpp"
+#include "./platform.hpp"
 #include "./services.hpp"
 #include "./utils.hpp"
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -4,11 +4,14 @@
 #include "./utils/base64.hpp"
 #include "./utils/borrowed_ptr.hpp"
 #include "./utils/cmd_line.hpp"
+#include "./utils/contracts.hpp"
 #include "./utils/elapsed.hpp"
 #include "./utils/intrusive_list.hpp"
 #include "./utils/non_pointer.hpp"
 #include "./utils/pool.hpp"
 #include "./utils/receiver.hpp"
 #include "./utils/result.hpp"
+#include "./utils/scope_guard.hpp"
+#include "./utils/symbol.hpp"
 
 #endif // SHADOW_CAST_UTILS_HPP_INCLUDED

--- a/src/utils/contracts.cpp
+++ b/src/utils/contracts.cpp
@@ -1,0 +1,15 @@
+#include "utils/contracts.hpp"
+#include <cstdio>
+#include <exception>
+
+namespace sc
+{
+auto contract_check_failed(char const* msg, std::source_location loc) -> void
+{
+    std::printf("Contract check failed: %s - %s:%u\n",
+                msg,
+                loc.file_name(),
+                loc.line());
+    std::terminate();
+}
+} // namespace sc

--- a/src/utils/contracts.hpp
+++ b/src/utils/contracts.hpp
@@ -1,0 +1,21 @@
+#ifndef SHADOW_CAST_UTILS_CONTRACTS_HPP_INCLUDED
+#define SHADOW_CAST_UTILS_CONTRACTS_HPP_INCLUDED
+
+#include <source_location>
+
+#define SC_STRINGIFY_IMPL(s) #s
+#define SC_STRINGIFY(s) SC_STRINGIFY_IMPL(s)
+#define SC_EXPECT(cond)                                                        \
+    if (!(cond))                                                               \
+    ::sc::contract_check_failed(SC_STRINGIFY(cond))
+
+namespace sc
+{
+
+[[noreturn]] auto contract_check_failed(
+    char const* /*msg*/,
+    std::source_location /*loc*/ = std::source_location::current()) -> void;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_UTILS_CONTRACTS_HPP_INCLUDED

--- a/src/utils/scope_guard.hpp
+++ b/src/utils/scope_guard.hpp
@@ -1,0 +1,43 @@
+#ifndef SHADOW_CAST_UTILS_SCOPE_GUARD_HPP_INCLUDED
+#define SHADOW_CAST_UTILS_SCOPE_GUARD_HPP_INCLUDED
+
+#include <utility>
+
+#define SC_GEN_VAR_NAME_IMPL(pfx, line) pfx##line
+#define SC_GEN_VAR_NAME(pfx, line) SC_GEN_VAR_NAME_IMPL(pfx, line)
+#define SC_SCOPE_GUARD(fn)                                                     \
+    auto SC_GEN_VAR_NAME(scope_guard_, __LINE__) = ::sc::ScopeGuard            \
+    {                                                                          \
+        fn                                                                     \
+    }
+
+namespace sc
+{
+
+template <typename F>
+struct ScopeGuard
+{
+    explicit ScopeGuard(F&& f) noexcept
+        : fn { std::forward<F>(f) }
+    {
+    }
+
+    ~ScopeGuard()
+    {
+        if (active)
+            fn();
+    }
+
+    ScopeGuard(ScopeGuard const&) = delete;
+    auto operator=(ScopeGuard const&) -> ScopeGuard& = delete;
+    ScopeGuard(ScopeGuard&&) = delete;
+    auto operator=(ScopeGuard&&) -> ScopeGuard& = delete;
+    auto deactivate() noexcept -> void { active = false; }
+
+    F fn;
+    bool active { true };
+};
+
+} // namespace sc
+
+#endif // SHADOW_CAST_UTILS_SCOPE_GUARD_HPP_INCLUDED

--- a/src/utils/symbol.hpp
+++ b/src/utils/symbol.hpp
@@ -1,0 +1,22 @@
+#ifndef SHADOW_CAST_UTILS_SYMBOL_HPP_INCLUDED
+#define SHADOW_CAST_UTILS_SYMBOL_HPP_INCLUDED
+
+#include "error.hpp"
+#include <dlfcn.h>
+
+#define TRY_ATTACH_SYMBOL(target, name, lib)                                   \
+    ::sc::attach_symbol(target, name, lib)
+
+namespace sc
+{
+template <typename F>
+auto attach_symbol(F** fn, char const* name, void* lib) -> void
+{
+    *fn = reinterpret_cast<F*>(dlsym(lib, name));
+    if (!*fn)
+        throw sc::ModuleError { std::string { "Couldn't load symbol: " } +
+                                name };
+}
+} // namespace sc
+
+#endif // SHADOW_CAST_UTILS_SYMBOL_HPP_INCLUDED

--- a/tools/install-helper.sh.in
+++ b/tools/install-helper.sh.in
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+install_prefix="@CMAKE_INSTALL_PREFIX@"
+project_dir="@PROJECT_SOURCE_DIR@"
+build_dir="@PROJECT_BINARY_DIR@"
+kms_bin_name="@SHADOW_CAST_KMS_BINARY_NAME@"
+
+printf \
+    "%s\n%s\n" \
+    "${install_prefix}" \
+    "${project_dir}"
+
+cmake \
+    --build "${build_dir}" \
+    --target install \
+    -- -j$(nproc)
+
+setcap \
+    cap_sys_admin+ep \
+    "${install_prefix}/bin/${kms_bin_name}"


### PR DESCRIPTION
This PR adds support for Wayland.

Wayland capture doesn't support NvFBC, so instead accesses the framebuffer via KMS/DRM.

A separate child process is spawned, which exports the framebuffer [*dma-buf*][1] over a unix domain socket to the parent process. The *dma-buf* is loaded into GPU texture memory and copied into the libav H/W context using CUDA. Exporting the *dma-buf* objects requires the calling process to have `cap_sys_admin` capabilities, so delegating this operation to a separate binary feels more appropriate.

[1]: https://www.kernel.org/doc/html/latest/driver-api/dma-buf.html
