### PR TITLE
fix(#17) Support for building against ffmpeg6

### DIFF
--- a/.versioning/changes/a0BeZgsmuY.patch.md
+++ b/.versioning/changes/a0BeZgsmuY.patch.md
@@ -1,0 +1,1 @@
+Fixes build incompatibilities with ffmpeg6 - thankyou, @guihkx (#17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ find_package(
         avdevice
         avfilter
         avformat
-        avresample
         avutil
         swresample
         swscale

--- a/cmake/FindFFMpeg.cmake
+++ b/cmake/FindFFMpeg.cmake
@@ -85,7 +85,6 @@ try_find_ffmpeg_targets(
         avdevice
         avfilter
         avformat
-        avresample
         avutil
         swresample
         swscale

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,6 @@ target_link_libraries(shadow-cast-obj
     FFMpeg::avdevice
     FFMpeg::avfilter
     FFMpeg::avformat
-    FFMpeg::avresample
     FFMpeg::avutil
     FFMpeg::swresample
     FFMpeg::swscale

--- a/src/av/codec.cpp
+++ b/src/av/codec.cpp
@@ -21,7 +21,7 @@ auto create_video_encoder(std::string const& encoder_name,
                           std::uint32_t fps,
                           AVPixelFormat pixel_format) -> sc::CodecContextPtr
 {
-    sc::BorrowedPtr<AVCodec> video_encoder { avcodec_find_encoder_by_name(
+    sc::BorrowedPtr<AVCodec const> video_encoder { avcodec_find_encoder_by_name(
         encoder_name.c_str()) };
     if (!video_encoder) {
         throw CodecError { "Failed to find required video codec" };

--- a/src/av/sample_format.hpp
+++ b/src/av/sample_format.hpp
@@ -3,6 +3,7 @@
 
 #include "av/fwd.hpp"
 #include "utils/borrowed_ptr.hpp"
+#include <cinttypes>
 #include <spa/param/audio/format-utils.h>
 #include <span>
 #include <stdexcept>

--- a/src/platform/wayland.hpp
+++ b/src/platform/wayland.hpp
@@ -2,6 +2,7 @@
 #define SHADOW_CAST_PLATFORM_WAYLAND_HPP_INCLUDED
 
 #include "./egl.hpp"
+#include <cinttypes>
 #include <memory>
 #include <type_traits>
 #include <wayland-client.h>

--- a/src/services/video_service.cpp
+++ b/src/services/video_service.cpp
@@ -4,12 +4,10 @@ namespace sc
 {
 
 VideoService::VideoService(
-    NvCuda nvcuda,
     NvFBC nvfbc,
     BorrowedPtr<std::remove_pointer_t<CUcontext>> nvcuda_ctx,
     NVFBC_SESSION_HANDLE nvfbc_session) noexcept
-    : nvcuda_ { nvcuda }
-    , nvfbc_ { nvfbc }
+    : nvfbc_ { nvfbc }
     , nvcuda_ctx_ { nvcuda_ctx }
     , nvfbc_session_ { nvfbc_session }
 {
@@ -29,9 +27,7 @@ auto dispatch_frame(Service& svc) -> void
 
     NVFBC_TOCUDA_GRAB_FRAME_PARAMS grab_params {};
     grab_params.dwVersion = NVFBC_TOCUDA_GRAB_FRAME_PARAMS_VER;
-    grab_params.dwFlags =
-        NVFBC_TOCUDA_GRAB_FLAGS_NOWAIT; /* |
-                                           NVFBC_TOCUDA_GRAB_FLAGS_FORCE_REFRESH;*/
+    grab_params.dwFlags = NVFBC_TOCUDA_GRAB_FLAGS_NOWAIT;
     grab_params.pFrameGrabInfo = &frame_info;
     grab_params.pCUDADeviceBuffer = &cu_device_ptr;
     grab_params.dwTimeoutMs = 0;

--- a/src/services/video_service.hpp
+++ b/src/services/video_service.hpp
@@ -16,8 +16,7 @@ struct VideoService final : Service
     using CaptureFrameReceiverType =
         Receiver<void(CUdeviceptr, NVFBC_FRAME_GRAB_INFO)>;
 
-    VideoService(NvCuda,
-                 NvFBC,
+    VideoService(NvFBC,
                  BorrowedPtr<std::remove_pointer_t<CUcontext>>,
                  NVFBC_SESSION_HANDLE) noexcept;
 
@@ -31,7 +30,6 @@ protected:
     auto on_init(ReadinessRegister) -> void override;
 
 private:
-    NvCuda nvcuda_;
     NvFBC nvfbc_;
     BorrowedPtr<std::remove_pointer_t<CUcontext>> nvcuda_ctx_;
     NVFBC_SESSION_HANDLE nvfbc_session_;


### PR DESCRIPTION
- Removes deprecated `avresample` dependency
- Adds `const` correct return values for `avcodec_find_encoder_by_name()`
- Fixes some missing `#includes` and unused variable warnings on Clang
- Detect of ffmpeg6 and use of non-deprecated `AVFrame` properties.
- Use version agnostic buffer size type

(thankyou, @guihkx)

resolves #17