### PR TITLE
fix(#18) No values accepted for `-V` option, valid or otherwise

### DIFF
--- a/.versioning/changes/LRSQqkg6f8.patch.md
+++ b/.versioning/changes/LRSQqkg6f8.patch.md
@@ -1,0 +1,1 @@
+Fixes a bug that caused no valid values to be accepted for the `-V` cmdline option (#18)

--- a/src/utils/cmd_line.cpp
+++ b/src/utils/cmd_line.cpp
@@ -14,6 +14,15 @@ using namespace std::literals::string_literals;
 
 namespace
 {
+
+template <typename Container, typename... T>
+constexpr auto construct(T... vals) noexcept -> Container
+requires(sizeof...(T) <= std::tuple_size<Container>::value) &&
+        ((std::is_convertible_v<T, std::string_view>) && ...)
+{
+    return { std::string_view { vals }... };
+}
+
 sc::CmdLineOptionSpec const cmd_line_spec[] = {
     /* Audio encoder...
      */
@@ -76,7 +85,8 @@ sc::CmdLineOptionSpec const cmd_line_spec[] = {
         .long_name = "--video-encoder",
         .option = sc::CmdLineOption::video_encoder,
         .flags = sc::cmdline::VALUE_REQUIRED,
-        .validation = sc::AcceptableValues { "h264_nvenc", "hevc_nvenc" },
+        .validation =
+            construct<sc::AcceptableValues>("h264_nvenc", "hevc_nvenc"),
         .description = "Video encoder to use. Valid values are 'h264_nvenc', "
                        "'hevc_nvenc'. Default 'hevc_nvenc'",
     },

--- a/src/utils/cmd_line.hpp
+++ b/src/utils/cmd_line.hpp
@@ -4,6 +4,7 @@
 #include "error.hpp"
 #include "utils/result.hpp"
 #include <algorithm>
+#include <array>
 #include <cinttypes>
 #include <cstddef>
 #include <string>
@@ -52,7 +53,7 @@ struct NoValidation
 };
 [[maybe_unused]] NoValidation constexpr no_validation {};
 
-using AcceptableValues = std::initializer_list<std::string_view>;
+using AcceptableValues = std::array<std::string_view, 16>;
 using ValidRange = std::tuple<std::int32_t, std::int32_t>;
 using Validation = std::variant<AcceptableValues, ValidRange, NoValidation>;
 
@@ -69,7 +70,7 @@ struct CmdLineOptionSpec
     std::string_view long_name;
     CmdLineOption option;
     std::uint32_t flags;
-    Validation validation;
+    Validation validation {};
     std::string_view description;
 };
 

--- a/tests/cmd_line_tests.cpp
+++ b/tests/cmd_line_tests.cpp
@@ -3,9 +3,8 @@
 
 auto should_parse() -> void
 {
-    char const* argv[] = {
-        "-f30", "-A", "libopus", "/tmp/test.mp4", "-h", "-v"
-    };
+    char const* argv[] = { "-V",      "h264_nvenc",    "-f30", "-A",
+                           "libopus", "/tmp/test.mp4", "-h",   "-v" };
 
     auto const cmdline = sc::parse_cmd_line(std::size(argv), argv);
 
@@ -15,9 +14,9 @@ auto should_parse() -> void
     EXPECT(cmdline.get_option_value(sc::CmdLineOption::frame_rate,
                                     sc::number_value) == 30);
 
-    EXPECT(!cmdline.has_option(sc::CmdLineOption::video_encoder));
-    EXPECT(cmdline.get_option_value_or_default(sc::CmdLineOption::video_encoder,
-                                               "hevc_nvenc") == "hevc_nvenc");
+    EXPECT(cmdline.has_option(sc::CmdLineOption::video_encoder));
+    EXPECT(cmdline.get_option_value(sc::CmdLineOption::video_encoder) ==
+           "h264_nvenc");
 
     EXPECT(cmdline.has_option(sc::CmdLineOption::audio_encoder));
     EXPECT(cmdline.get_option_value(sc::CmdLineOption::audio_encoder) ==


### PR DESCRIPTION
This fixes a bug where acceptable values were not accepted on the cmdline for the `-V` options.

resolves #18