### PR TITLE
fix(#22) Make `cppcheck` an optional requirement for building source

### DIFF
--- a/.versioning/changes/fDytaqESBG.patch.md
+++ b/.versioning/changes/fDytaqESBG.patch.md
@@ -1,0 +1,1 @@
+Fixes an issue where the build would fail if `cppcheck` executable wasn't available

--- a/cmake/CPPCheck.cmake
+++ b/cmake/CPPCheck.cmake
@@ -4,4 +4,6 @@ if(CMAKE_CXX_CPPCHECK AND CMAKE_BUILD_TYPE STREQUAL "Debug")
         "--enable=warning"
         "--error-exitcode=1"
     )
+else()
+    set(CMAKE_CXX_CPPCHECK "")
 endif()


### PR DESCRIPTION
resolves #22