### PR TITLE
feat(performance) Multiple performance improvements and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .private/
 experimental/
 dist/
+report/

--- a/.versioning/changes/DyxXCHexJS.minor.md
+++ b/.versioning/changes/DyxXCHexJS.minor.md
@@ -1,0 +1,1 @@
+Improves encoding performance by using a dedicated thread

--- a/.versioning/changes/S9GbUeHXdB.minor.md
+++ b/.versioning/changes/S9GbUeHXdB.minor.md
@@ -1,1 +1,1 @@
-Adds a build-time option to enable timing metric collection for audio & video
+Adds a build-time option to enable frame time metric collection

--- a/.versioning/changes/UaFV3jPgO3.minor.md
+++ b/.versioning/changes/UaFV3jPgO3.minor.md
@@ -1,0 +1,1 @@
+Reduces frame "jitter" when capturing certain games in X11

--- a/.versioning/changes/wekMseGz7z.patch.md
+++ b/.versioning/changes/wekMseGz7z.patch.md
@@ -1,0 +1,1 @@
+Fixes a memory leak in H/W encoding pipeline

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Typical screen capture utilities copy the framebuffer data between host and GPU 
 - [Building from source](#building-from-source)
 - [Installing](#installing)
 - [Alternative projects](#some-alternative-projects)
+- [FAQ](doc/faq.md)
 
 #### Example - Cyberpunk 2077
 [![Cyberpunk 2077](http://i3.ytimg.com/vi/frXGxrdgTLY/hqdefault.jpg)](https://www.youtube.com/watch?v=frXGxrdgTLY)
@@ -26,20 +27,14 @@ The resulting media/container type is determined by the extension of `<OUTPUT FI
 
 If no `OPTIONS` are specified then *Shadow Cast* will pick some sensible defaults for the audio/video encoders and sample/frame rates, but these can be changed by specifying the following `OPTIONS` on the command line...
 
-- `-A <AUDIO ENCODER>` - All options available to `ffmpeg` should work here. Defaults to `libopus`
-- `-V <VIDEO ENCODER>` - Available options are `h264_nvenc` and `hevc_nvenc`. Defaults to `hevc_nvenc`
-- `-f <FRAME RATE>` - Values from `20` to `60` are accepted. Defaults to `60`
-- `-s <SAMPLE RATE>` - Defaults to `48000` (_NOTE: Some encoders will only support certain sample rates. Shadow Cast will display an error if your chosen sample rate isn't supported_)
+| Option                    | Description   |
+|---------                  |------------   |
+| `-A <AUDIO ENCODER>`      | Audio encoder. All options available to `ffmpeg` should work here. Defaults to `libopus` |
+| `-V <VIDEO ENCODER>`      | Video encoder. Available options are `h264_nvenc` and `hevc_nvenc`. defaults to `hevc_nvenc` |
+| `-f <FRAMES PER SECOND>`  | Capture FPS. values from `20` to `70` are accepted. defaults to `60`  |
+| `-s <SAMPLE RATE>`        | Audio sample rate. Defaults to `48000` (_NOTE: Some encoders will only support certain sample rates. Shadow Cast will display an error if your chosen sample rate isn't supported_) |
 
 Ctrl+C / SIGINT will stop the capture session and finalize the output media.
-
-### Help. I'm getting the following error
-
-#### `ERROR: Couldn't create NvFBC instance`
-*Shadow Cast* uses the *NvFBC* facility to provide efficient, low-latency framebuffer capture on X11. By default, NVIDIA disables this on most (if not all) of its consumer-level GPUs. However, there are two ways around this restriction...
-
-- You can find a utility to patch your NVIDIA drivers in the [keylase/nvidia-patch](https://github.com/keylase/nvidia-patch) GitHub repo.
-- You can obtain a "key" to unlock this feature at runtime. The key can be set at runtime via the `SHADOW_CAST_NVFBC_KEY=<BASE64 ENCODED KEY>` environment variable. I use this method but I'm not sure how "official" it is, so no keys are provided in this repo. Feel free to message me about this.
 
 ### Requirements
 - FFMpeg (libav)

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,0 +1,24 @@
+### Q. Help, I'm getting the following error
+
+```
+ERROR: Couldn't create NvFBC instance
+```
+
+#### A.
+*Shadow Cast* uses the *NvFBC* facility to provide efficient, low-latency framebuffer capture on X11. By default, NVIDIA disables this on most (if not all) of its consumer-level GPUs. However, there are two ways around this restriction...
+
+- You can find a utility to patch your NVIDIA drivers in the [keylase/nvidia-patch](https://github.com/keylase/nvidia-patch) GitHub repo.
+- You can obtain a "key" to unlock this feature at runtime. The key can be set at runtime via the `SHADOW_CAST_NVFBC_KEY=<BASE64 ENCODED KEY>` environment variable. I use this method but I'm not sure how "official" it is, so no keys are provided in this repo. Feel free to message me about this.
+
+### Q. I'm capturing gameplay footage on X11 and my game is "laggy"
+
+#### A.
+In some games, the NVIDIA Capture library (*NvFBC*) appears to interact poorly with v-sync if your refresh rate matches the capture FPS. Try disabling v-sync. Another option you can try is to set the following environment variable when capturing...
+
+```
+$ SHADOW_CAST_STRICT_FPS=0 shadow-cast ...
+```
+
+Please note, however, using this option will scale the output video's frame rate to match NvFBC's closest match (e.g. `62.5` in the case of a 60fps capture).
+
+I haven't quite worked out the definitive cause of this "lagginess", but I suspect it is because NvFBC only accepts integer millisecond values as its sampling rate, so cannot exactly match *Shadow Cast*'s frame rate. For example, 60fps would require a fractional sampling frequency of `16.666` milliseconds, and NvFBC only allows either `16` or `17` milliseconds.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,8 @@ add_library(shadow-cast-obj
     services/audio_service.cpp
     services/context.cpp
     services/drm_video_service.cpp
+    services/encoder.cpp
+    services/encoder_service.cpp
     services/metrics_service.cpp
     services/readiness.cpp
     services/service.cpp
@@ -42,10 +44,11 @@ add_library(shadow-cast-obj
     services/signal_service.cpp
     services/video_service.cpp
 
+    utils/base64.cpp
     utils/cmd_line.cpp
     utils/contracts.cpp
-    utils/base64.cpp
     utils/elapsed.cpp
+    utils/frame_time.cpp
     utils/result.cpp
 
     error.cpp

--- a/src/av/codec.hpp
+++ b/src/av/codec.hpp
@@ -25,7 +25,7 @@ auto create_video_encoder(std::string const& encoder_name,
                           CUcontext cuda_ctx,
                           AVBufferPool* pool,
                           VideoOutputSize size,
-                          std::uint32_t fps,
+                          FrameTime const& ft,
                           AVPixelFormat pixel_format) -> sc::CodecContextPtr;
 } // namespace sc
 

--- a/src/handlers/audio_chunk_writer.hpp
+++ b/src/handlers/audio_chunk_writer.hpp
@@ -2,6 +2,7 @@
 #define SHADOW_CAST_HANDLERS_AUDIO_CHUNK_WRITER_HPP_INCLUDED
 
 #include "av.hpp"
+#include "services/encoder.hpp"
 #include "utils/borrowed_ptr.hpp"
 
 namespace sc
@@ -9,19 +10,18 @@ namespace sc
 
 struct ChunkWriter
 {
-    explicit ChunkWriter(AVFormatContext* format_context,
-                         AVCodecContext* codec_context,
-                         AVStream* stream) noexcept;
+    explicit ChunkWriter(AVCodecContext* codec_context,
+                         AVStream* stream,
+                         Encoder encoder) noexcept;
 
     auto operator()(MediaChunk const& chunk) -> void;
 
 private:
-    BorrowedPtr<AVFormatContext> format_context_;
     BorrowedPtr<AVCodecContext> codec_context_;
     BorrowedPtr<AVStream> stream_;
+    Encoder encoder_;
     FramePtr frame_;
     std::size_t total_samples_written_ { 0 };
-    PacketPtr packet_;
 };
 
 } // namespace sc

--- a/src/handlers/drm_video_frame_writer.hpp
+++ b/src/handlers/drm_video_frame_writer.hpp
@@ -3,24 +3,24 @@
 
 #include "av.hpp"
 #include "nvidia.hpp"
+#include "services/encoder.hpp"
+#include <cstdint>
 
 namespace sc
 {
 struct DRMVideoFrameWriter
 {
-    DRMVideoFrameWriter(AVFormatContext* fmt_context,
-                        AVCodecContext* codec_context,
-                        AVStream* stream);
+    DRMVideoFrameWriter(AVCodecContext* codec_context,
+                        AVStream* stream,
+                        Encoder encoder);
 
-    auto operator()(CUarray, NvCuda const&) -> void;
+    auto operator()(CUarray, NvCuda const&, std::uint64_t) -> void;
 
 private:
-    BorrowedPtr<AVFormatContext> format_context_;
     BorrowedPtr<AVCodecContext> codec_context_;
     BorrowedPtr<AVStream> stream_;
-    FramePtr frame_;
+    Encoder encoder_;
     std::size_t frame_number_ { 0 };
-    PacketPtr packet_;
 };
 
 } // namespace sc

--- a/src/handlers/video_frame_writer.hpp
+++ b/src/handlers/video_frame_writer.hpp
@@ -3,24 +3,26 @@
 
 #include "av.hpp"
 #include "nvidia.hpp"
+#include "services/encoder.hpp"
+#include <cstdint>
 
 namespace sc
 {
 struct VideoFrameWriter
 {
-    VideoFrameWriter(AVFormatContext* fmt_context,
-                     AVCodecContext* codec_context,
-                     AVStream* stream);
+    VideoFrameWriter(AVCodecContext* codec_context,
+                     AVStream* stream,
+                     Encoder encoder);
 
-    auto operator()(CUdeviceptr cu_device_ptr, NVFBC_FRAME_GRAB_INFO) -> void;
+    auto operator()(CUdeviceptr cu_device_ptr,
+                    NVFBC_FRAME_GRAB_INFO,
+                    std::uint64_t) -> void;
 
 private:
-    BorrowedPtr<AVFormatContext> format_context_;
     BorrowedPtr<AVCodecContext> codec_context_;
     BorrowedPtr<AVStream> stream_;
-    FramePtr frame_;
+    Encoder encoder_;
     std::size_t frame_number_ { 0 };
-    PacketPtr packet_;
 };
 
 } // namespace sc

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -1,6 +1,7 @@
 #include "nvidia.hpp"
 #include "nvidia/cuda.hpp"
 #include "utils/base64.hpp"
+#include "utils/frame_time.hpp"
 #include "utils/symbol.hpp"
 #include <dlfcn.h>
 
@@ -145,14 +146,14 @@ auto create_nvfbc_session(sc::NvFBC instance) -> sc::NvFBCSessionHandlePtr
 
 auto create_nvfbc_capture_session(NVFBC_SESSION_HANDLE nvfbc_handle,
                                   NvFBC nvfbc,
-                                  std::uint32_t fps) -> void
+                                  FrameTime const& frame_time) -> void
 {
     NVFBC_CREATE_CAPTURE_SESSION_PARAMS create_capture_params {};
     create_capture_params.dwVersion = NVFBC_CREATE_CAPTURE_SESSION_PARAMS_VER;
     create_capture_params.eCaptureType = NVFBC_CAPTURE_SHARED_CUDA;
     create_capture_params.bWithCursor = NVFBC_TRUE;
     create_capture_params.eTrackingType = NVFBC_TRACKING_SCREEN;
-    create_capture_params.dwSamplingRateMs = 1000u / fps;
+    create_capture_params.dwSamplingRateMs = frame_time.value_in_milliseconds();
     create_capture_params.bAllowDirectCapture = NVFBC_FALSE;
     create_capture_params.bPushModel = NVFBC_FALSE;
 
@@ -162,7 +163,7 @@ auto create_nvfbc_capture_session(NVFBC_SESSION_HANDLE nvfbc_handle,
 
     NVFBC_TOCUDA_SETUP_PARAMS setup_params {};
     setup_params.dwVersion = NVFBC_TOCUDA_SETUP_PARAMS_VER;
-    setup_params.eBufferFormat = NVFBC_BUFFER_FORMAT_YUV444P;
+    setup_params.eBufferFormat = NVFBC_BUFFER_FORMAT_BGRA;
 
     if (nvfbc.nvFBCToCudaSetUp(nvfbc_handle, &setup_params) != NVFBC_SUCCESS)
         throw sc::NvFBCError { nvfbc, nvfbc_handle };

--- a/src/nvidia.hpp
+++ b/src/nvidia.hpp
@@ -64,7 +64,7 @@ auto load_nvfbc() -> NvFBCLib;
 
 auto create_nvfbc_capture_session(NVFBC_SESSION_HANDLE nvfbc_handle,
                                   NvFBC nvfbc,
-                                  std::uint32_t fps) -> void;
+                                  FrameTime const&) -> void;
 auto destroy_nvfbc_capture_session(NVFBC_SESSION_HANDLE nvfbc_handle,
                                    NvFBC nvfbc) -> void;
 } // namespace sc

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -6,6 +6,8 @@
 #include "./services/audio_service.hpp"
 #include "./services/context.hpp"
 #include "./services/drm_video_service.hpp"
+#include "./services/encoder.hpp"
+#include "./services/encoder_service.hpp"
 #ifdef SHADOW_CAST_ENABLE_METRICS
 #include "./services/metrics_service.hpp"
 #endif

--- a/src/services/audio_service.cpp
+++ b/src/services/audio_service.cpp
@@ -246,6 +246,7 @@ AudioService::AudioService(SampleFormat sample_format,
     , sample_rate_ { sample_rate }
     , frame_size_ { frame_size } // clang-format off
     SC_METRICS_MEMBER_USE(metrics_service, metrics_service_)
+    SC_METRICS_MEMBER_USE(0, metrics_start_time_)
 // clang-format on
 {
 #ifdef SHADOW_CAST_ENABLE_METRICS
@@ -265,7 +266,7 @@ auto AudioService::chunk_pool() noexcept -> SynchronizedPool<MediaChunk>&
 
 auto AudioService::on_init(ReadinessRegister reg) -> void
 {
-    reg(FrameTimeRatio(1, 2), &dispatch_chunks);
+    reg(FrameTimeRatio(1), &dispatch_chunks);
 
     loop_data_ = {};
     loop_data_.service = this;

--- a/src/services/context.cpp
+++ b/src/services/context.cpp
@@ -1,13 +1,16 @@
 #include "services/context.hpp"
 #include "services/readiness.hpp"
 #include "utils/elapsed.hpp"
+#include "utils/scope_guard.hpp"
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <cstddef>
 #include <errno.h>
 #include <limits>
 #include <poll.h>
 #include <signal.h>
+#include <sys/eventfd.h>
 #include <system_error>
 #include <tuple>
 #include <vector>
@@ -67,21 +70,34 @@ auto tick_timers(sc::ReadinessRegister::FrameTickRegisterType& timers,
 
 namespace sc
 {
+Context::Context(FrameTime const& ft) noexcept
+    : frame_time_ { ft.value() }
+{
+}
+
 Context::Context(std::uint32_t fps) noexcept
-    : fps_ { fps }
+    : frame_time_ { from_fps(fps).value() }
 {
 }
 
 auto Context::services() noexcept -> ServiceRegistry& { return reg_; }
 
-auto Context::request_stop() noexcept -> void { stop_requested_ = true; }
+auto Context::request_stop() noexcept -> void
+{
+    stop_requested_ = true;
+    std::uint64_t event { 1 };
+    ::write(event_fd_, &event, sizeof(event));
+}
 
 auto Context::run() -> void
 {
     using Notifications = ReadinessRegister::NotifyRegisterType;
     using Timers = ReadinessRegister::FrameTickRegisterType;
 
-    auto const frame_time_in_ns = kNsPerSec / fps_;
+    if (event_fd_ = ::eventfd(0, EFD_NONBLOCK); event_fd_ < 0)
+        throw std::system_error { errno, std::system_category() };
+
+    SC_SCOPE_GUARD([&] { ::close(event_fd_); });
 
     Notifications notifications;
     Timers timers;
@@ -96,8 +112,8 @@ auto Context::run() -> void
     try {
         for (; initialized_pos != reg_.end(); ++initialized_pos) {
             auto& svc = std::get<1>(*initialized_pos);
-            svc->init(ReadinessRegister {
-                *svc, notifications, timers, frame_time_in_ns });
+            svc->init(
+                ReadinessRegister { *svc, notifications, timers, frame_time_ });
         }
     }
     catch (...) {
@@ -118,7 +134,8 @@ auto Context::run() -> void
     }
 
     std::vector<pollfd> poll_events;
-    poll_events.reserve(notifications.size());
+    poll_events.reserve(notifications.size() + 1);
+    poll_events.push_back({ event_fd_, POLLIN, 0 });
 
     std::transform(begin(notifications),
                    end(notifications),
@@ -127,7 +144,7 @@ auto Context::run() -> void
                        return pollfd { std::get<0>(notification), POLLIN, 0 };
                    });
 
-    Elapsed const elapsed;
+    Elapsed const& elapsed = global_elapsed;
     auto frame_start = elapsed.nanosecond_value();
 
     while (!stop_requested_) {
@@ -135,8 +152,7 @@ auto Context::run() -> void
         auto const frame_time = frame_stop - frame_start;
         frame_start = frame_stop;
 
-        auto const next_timeout =
-            tick_timers(timers, frame_time, frame_time_in_ns);
+        auto const next_timeout = tick_timers(timers, frame_time, frame_time_);
 
         auto sleep_for = from_nanoseconds(next_timeout);
         auto const poll_result =
@@ -150,8 +166,21 @@ auto Context::run() -> void
 
         if (poll_result > 0) {
             for (auto const& ev : poll_events) {
+
                 if (!(ev.revents & POLLIN))
                     continue;
+
+                if (ev.fd == event_fd_) {
+                    std::uint64_t discard;
+                    if (auto const result =
+                            ::read(event_fd_, &discard, sizeof(discard));
+                        result < 0)
+                        if (errno != EAGAIN)
+                            throw std::system_error { errno,
+                                                      std::system_category() };
+
+                    continue;
+                }
 
                 auto notify = notifications.find(ev.fd);
                 if (notify != notifications.end()) {

--- a/src/services/context.hpp
+++ b/src/services/context.hpp
@@ -2,6 +2,7 @@
 #define SHADOW_CAST_SERVICES_CONTEXT_HPP_INCLUDED
 
 #include "services/service_registry.hpp"
+#include "utils/frame_time.hpp"
 #include <atomic>
 
 namespace sc
@@ -9,6 +10,7 @@ namespace sc
 
 struct Context
 {
+    explicit Context(FrameTime const&) noexcept;
     explicit Context(std::uint32_t = 60) noexcept;
     Context(Context const&) = delete;
     auto operator=(Context const&) -> Context& = delete;
@@ -18,9 +20,10 @@ struct Context
     auto request_stop() noexcept -> void;
 
 private:
+    std::uint64_t frame_time_;
     std::atomic<bool> stop_requested_ { false };
     ServiceRegistry reg_;
-    std::uint32_t fps_;
+    int event_fd_ { -1 };
 };
 
 } // namespace sc

--- a/src/services/drm_video_service.cpp
+++ b/src/services/drm_video_service.cpp
@@ -115,6 +115,7 @@ DRMVideoService::DRMVideoService(
     , wayland_ { &wayland }
     , platform_egl_ { &plaform_egl } // clang-format off
     SC_METRICS_MEMBER_USE(metrics_service, metrics_service_)
+    SC_METRICS_MEMBER_USE(0, metrics_start_time_)
 // clang-format on
 {
 #ifdef SHADOW_CAST_ENABLE_METRICS
@@ -161,6 +162,7 @@ auto DRMVideoService::on_init(ReadinessRegister reg) -> void
     egl_->eglSwapInterval(platform_egl_->egl_display.get(), 0);
 
     reg(FrameTimeRatio(1), &dispatch_frame);
+    frame_time_ = reg.frame_time();
 
 #ifdef SHADOW_CAST_ENABLE_METRICS
     metrics_start_time_ = global_elapsed.nanosecond_value();
@@ -266,7 +268,7 @@ auto DRMVideoService::dispatch_frame(Service& svc) -> void
         }
     });
 
-    (*self.frame_handler_)(self.cuda_array_, self.nvcuda_);
+    (*self.frame_handler_)(self.cuda_array_, self.nvcuda_, self.frame_time_);
 
 #ifdef SHADOW_CAST_ENABLE_METRICS
     self.metrics_service_->post_time_metric(

--- a/src/services/drm_video_service.hpp
+++ b/src/services/drm_video_service.hpp
@@ -18,6 +18,7 @@
 #include "services/service.hpp"
 #include "utils/borrowed_ptr.hpp"
 #include "utils/receiver.hpp"
+#include <cstdint>
 #include <optional>
 #include <signal.h>
 
@@ -26,7 +27,8 @@ namespace sc
 
 struct DRMVideoService final : Service
 {
-    using CaptureFrameReceiverType = Receiver<void(CUarray, NvCuda const&)>;
+    using CaptureFrameReceiverType =
+        Receiver<void(CUarray, NvCuda const&, std::uint64_t)>;
 
     explicit DRMVideoService(NvCuda nvcuda,
                              CUcontext cuda_ctx,
@@ -63,6 +65,7 @@ private:
     SC_METRICS_MEMBER_DECLARE(MetricsService*, metrics_service_);
     SC_METRICS_MEMBER_DECLARE(Elapsed, frame_timer_);
     SC_METRICS_MEMBER_DECLARE(std::size_t, metrics_start_time_);
+    std::uint64_t frame_time_ { 0 };
 };
 
 } // namespace sc

--- a/src/services/encoder.cpp
+++ b/src/services/encoder.cpp
@@ -1,0 +1,37 @@
+#include "services/encoder.hpp"
+#include "utils/contracts.hpp"
+#include "utils/pool.hpp"
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+
+namespace sc
+{
+Encoder::Encoder(Context& ctx) noexcept
+    : svc_ { ctx.services().use_if<EncoderService>() }
+{
+    SC_EXPECT(svc_);
+}
+
+auto Encoder::write_frame(Frame&& item) -> void
+{
+    svc_->write_frame(std::move(item));
+}
+
+auto Encoder::flush(BorrowedPtr<AVCodecContext> codec_ctx,
+                    BorrowedPtr<AVStream> stream) -> void
+{
+    auto encoder_frame = prepare_frame(codec_ctx, stream);
+    encoder_frame->frame.reset();
+    svc_->write_frame(std::move(encoder_frame));
+}
+
+auto Encoder::prepare_frame(BorrowedPtr<AVCodecContext> codec_ctx,
+                            BorrowedPtr<AVStream> stream) -> Frame
+{
+    auto pool_item = svc_->pool().get();
+    pool_item->codec_ctx = codec_ctx.get();
+    pool_item->stream = stream.get();
+    return pool_item;
+}
+
+} // namespace sc

--- a/src/services/encoder.hpp
+++ b/src/services/encoder.hpp
@@ -1,0 +1,27 @@
+#ifndef SHADOW_CAST_SERVICES_MEDIA_WRITER_HPP_INCLUDED
+#define SHADOW_CAST_SERVICES_MEDIA_WRITER_HPP_INCLUDED
+
+#include "services/context.hpp"
+#include "services/encoder_service.hpp"
+#include "utils/borrowed_ptr.hpp"
+#include "utils/pool.hpp"
+
+namespace sc
+{
+struct Encoder
+{
+    using Frame = typename EncoderService::PoolType::ItemPtr;
+    explicit Encoder(Context&) noexcept;
+
+    auto write_frame(Frame&&) -> void;
+    auto flush(BorrowedPtr<AVCodecContext>, BorrowedPtr<AVStream>) -> void;
+
+    auto prepare_frame(BorrowedPtr<AVCodecContext>, BorrowedPtr<AVStream>)
+        -> Frame;
+
+private:
+    sc::BorrowedPtr<EncoderService> svc_;
+};
+} // namespace sc
+
+#endif // SHADOW_CAST_SERVICES_MEDIA_WRITER_HPP_INCLUDED

--- a/src/services/encoder_service.cpp
+++ b/src/services/encoder_service.cpp
@@ -1,0 +1,151 @@
+#include "services/encoder_service.hpp"
+#include "config.hpp"
+#include "error.hpp"
+#include "utils/pool.hpp"
+#include <cstring>
+#include <errno.h>
+#include <libavcodec/avcodec.h>
+#include <stdexcept>
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+using namespace std::literals::string_literals;
+
+namespace
+{
+std::size_t constexpr kInitialPoolSize = 16;
+}
+
+namespace sc
+{
+EncoderService::EncoderService(
+    BorrowedPtr<AVFormatContext> fmt_context
+        SC_METRICS_PARAM_DEFINE(MetricsService*, metrics_service)) noexcept
+    : format_context_ { fmt_context } SC_METRICS_MEMBER_USE(metrics_service,
+                                                            metrics_service_)
+    , packet_ { av_packet_alloc() }
+{
+}
+
+auto EncoderService::write_frame(PoolType::ItemPtr item) -> void
+{
+    {
+        std::lock_guard lock { data_mutex_ };
+        static_cast<void>(
+            avcodec_send_frame(item->codec_ctx, item->frame.get()));
+        pending_.push_back(item.release());
+    }
+
+    std::uint64_t const event_num { 1 };
+    static_cast<void>(::write(notify_fd_, &event_num, sizeof(event_num)));
+}
+
+auto EncoderService::on_init(ReadinessRegister reg) -> void
+{
+    if (notify_fd_ = ::eventfd(0, EFD_NONBLOCK); notify_fd_ < 0)
+        throw new std::runtime_error {
+            "EncoderService initialization failed: "s + std::strerror(errno)
+        };
+
+    pool_.fill(kInitialPoolSize);
+    reg(notify_fd_, &dispatch);
+#ifdef SHADOW_CAST_ENABLE_METRICS
+    metrics_start_time_ = global_elapsed.nanosecond_value();
+#endif
+}
+
+auto EncoderService::on_uninit() noexcept -> void
+{
+    static_cast<void>(::close(notify_fd_));
+    try {
+        dispatch(*this);
+        pool_.clear();
+    }
+    catch (...) {
+    }
+}
+
+auto EncoderService::dispatch(Service& svc) -> void
+{
+    auto& self = static_cast<EncoderService&>(svc);
+    std::uint64_t event_num;
+    static_cast<void>(::read(self.notify_fd_, &event_num, sizeof(event_num)));
+
+    IntrusiveList<StreamPoll> tmp;
+    {
+        std::lock_guard lock { self.data_mutex_ };
+        tmp.splice(tmp.begin(),
+                   self.pending_,
+                   self.pending_.begin(),
+                   self.pending_.end());
+    }
+
+    ReturnToPoolGuard return_to_pool_guard { tmp, self.pool_ };
+
+    for (auto const& stream_poll : tmp) {
+        auto* stream = stream_poll.stream;
+        auto* ctx = stream_poll.codec_ctx;
+        int response = 0;
+        while (response >= 0) {
+#ifdef SHADOW_CAST_ENABLE_METRICS
+            self.frame_timer_.reset();
+            auto const frame_timestamp =
+                global_elapsed.nanosecond_value() - self.metrics_start_time_;
+#endif
+            {
+                std::lock_guard lock { self.data_mutex_ };
+                response = avcodec_receive_packet(ctx, self.packet_.get());
+            }
+            if (response == AVERROR(EAGAIN) || response == AVERROR_EOF) {
+                break;
+            }
+
+            if (response < 0) {
+                throw std::runtime_error { "receive packet error" };
+            }
+
+            av_packet_rescale_ts(
+                self.packet_.get(), ctx->time_base, stream->time_base);
+            self.packet_->stream_index = stream->index;
+
+            response = av_interleaved_write_frame(self.format_context_.get(),
+                                                  self.packet_.get());
+            if (response < 0) {
+                throw std::runtime_error { "write packet error: " +
+                                           av_error_to_string(response) };
+            }
+#ifdef SHADOW_CAST_ENABLE_METRICS
+            self.metrics_service_->post_time_metric(
+                { .category = static_cast<std::uint32_t>(4 - stream->index),
+                  .id = 0,
+                  .timestamp_ns = frame_timestamp,
+                  .nanoseconds = self.frame_timer_.nanosecond_value(),
+                  .frame_size = 1,
+                  .frame_count = 1 });
+#endif
+        }
+    }
+}
+
+auto EncoderService::pool() noexcept -> PoolType& { return pool_; }
+
+StreamPoll::StreamPoll()
+    : codec_ctx { nullptr }
+    , stream { nullptr }
+    , frame { av_frame_alloc() }
+{
+}
+
+auto StreamPoll::reset() noexcept -> void
+{
+    codec_ctx = nullptr;
+    stream = nullptr;
+    if (!frame) {
+        frame = FramePtr { av_frame_alloc() };
+    }
+    else {
+        av_frame_unref(frame.get());
+    }
+}
+
+} // namespace sc

--- a/src/services/encoder_service.hpp
+++ b/src/services/encoder_service.hpp
@@ -1,0 +1,83 @@
+#ifndef SHADOW_CAST_SERVICES_MEDIA_WRITER_SERVICE_HPP_INCLUDED
+#define SHADOW_CAST_SERVICES_MEDIA_WRITER_SERVICE_HPP_INCLUDED
+
+#include "config.hpp"
+
+#ifdef SHADOW_CAST_ENABLE_METRICS
+#include "services/metrics_service.hpp"
+#include "utils/elapsed.hpp"
+#endif
+
+#include "av/frame.hpp"
+#include "av/packet.hpp"
+#include "services/readiness.hpp"
+#include "services/service.hpp"
+#include "utils/borrowed_ptr.hpp"
+#include "utils/intrusive_list.hpp"
+#include "utils/pool.hpp"
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+#include <mutex>
+
+namespace sc
+{
+
+struct StreamPoll : ListItemBase
+{
+    StreamPoll();
+
+    AVCodecContext* codec_ctx;
+    AVStream* stream;
+    FramePtr frame;
+
+    auto reset() noexcept -> void;
+};
+
+struct EncoderService final : Service
+{
+private:
+    struct EncoderPoolLifetime
+    {
+        auto construct(StreamPoll* item) -> void
+        {
+            new (static_cast<void*>(item)) StreamPoll {};
+            item->frame = FramePtr { av_frame_alloc() };
+        }
+
+        auto destruct(StreamPoll* item) -> void { item->~StreamPoll(); }
+    };
+
+public:
+    using PoolType = SynchronizedPool<StreamPoll, EncoderPoolLifetime>;
+    EncoderService(BorrowedPtr<AVFormatContext> SC_METRICS_PARAM_DECLARE(
+        MetricsService*)) noexcept;
+
+    EncoderService(EncoderService const&) = delete;
+    auto operator=(EncoderService const&) -> EncoderService& = delete;
+
+    auto write_frame(PoolType::ItemPtr) -> void;
+
+    auto pool() noexcept -> PoolType&;
+
+protected:
+    auto on_init(ReadinessRegister) -> void override;
+    auto on_uninit() noexcept -> void override;
+
+private:
+    static auto dispatch(Service&) -> void;
+
+    BorrowedPtr<AVFormatContext> format_context_;
+    SC_METRICS_MEMBER_DECLARE(MetricsService*, metrics_service_);
+    int notify_fd_ { -1 };
+    std::mutex data_mutex_;
+    PacketPtr packet_;
+    PoolType pool_;
+    IntrusiveList<StreamPoll> pending_;
+    SC_METRICS_MEMBER_DECLARE(Elapsed, frame_timer_);
+    SC_METRICS_MEMBER_DECLARE(std::size_t, metrics_start_time_);
+};
+} // namespace sc
+
+#endif // SHADOW_CAST_SERVICES_MEDIA_WRITER_SERVICE_HPP_INCLUDED

--- a/src/services/video_service.hpp
+++ b/src/services/video_service.hpp
@@ -21,7 +21,7 @@ struct VideoService final : Service
     friend auto dispatch_frame(Service&) -> void;
 
     using CaptureFrameReceiverType =
-        Receiver<void(CUdeviceptr, NVFBC_FRAME_GRAB_INFO)>;
+        Receiver<void(CUdeviceptr, NVFBC_FRAME_GRAB_INFO, std::uint64_t)>;
 
     VideoService(NvFBC,
                  BorrowedPtr<std::remove_pointer_t<CUcontext>>,
@@ -46,6 +46,7 @@ private:
     SC_METRICS_MEMBER_DECLARE(MetricsService*, metrics_service_);
     SC_METRICS_MEMBER_DECLARE(Elapsed, frame_timer_);
     SC_METRICS_MEMBER_DECLARE(std::size_t, metrics_start_time_);
+    std::uint64_t frame_time_ { 0 };
 };
 
 auto dispatch_frame(Service&) -> void;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -6,6 +6,7 @@
 #include "./utils/cmd_line.hpp"
 #include "./utils/contracts.hpp"
 #include "./utils/elapsed.hpp"
+#include "./utils/frame_time.hpp"
 #include "./utils/intrusive_list.hpp"
 #include "./utils/non_pointer.hpp"
 #include "./utils/pool.hpp"

--- a/src/utils/cmd_line.hpp
+++ b/src/utils/cmd_line.hpp
@@ -2,6 +2,7 @@
 #define SHADOW_CAST_UTILS_CMD_LINE_HPP_INCLUDED
 
 #include "error.hpp"
+#include "utils/frame_time.hpp"
 #include "utils/result.hpp"
 #include <algorithm>
 #include <array>
@@ -43,9 +44,10 @@ struct Parameters
 {
     std::string video_encoder;
     std::string audio_encoder;
-    std::int32_t frame_rate;
+    FrameTime frame_time;
     std::int32_t sample_rate;
     std::string output_file;
+    bool strict_frame_time { true };
 };
 
 struct NoValidation

--- a/src/utils/frame_time.cpp
+++ b/src/utils/frame_time.cpp
@@ -1,0 +1,49 @@
+#include "utils/frame_time.hpp"
+#include <libavutil/rational.h>
+
+namespace
+{
+std::uint64_t constexpr kNsPerSec = 1'000'000'000;
+std::uint64_t constexpr kNsPerMs = 1'000'000;
+auto constexpr kRound = kNsPerMs / 2;
+
+} // namespace
+namespace sc
+{
+
+FrameTime::FrameTime(std::uint64_t frame_time_nanoseconds) noexcept
+    : frame_time_nanoseconds_ { frame_time_nanoseconds }
+{
+}
+
+auto FrameTime::value() const noexcept -> std::uint64_t
+{
+    return frame_time_nanoseconds_;
+}
+
+auto FrameTime::value_in_milliseconds() const noexcept -> std::uint64_t
+{
+    return (frame_time_nanoseconds_ + kRound) / kNsPerMs;
+}
+
+auto FrameTime::fps() const noexcept -> float
+{
+    return static_cast<float>(kNsPerSec) / frame_time_nanoseconds_;
+}
+
+auto FrameTime::per_second_ratio() const noexcept -> AVRational
+{
+    return AVRational { .num = 1, .den = kNsPerSec };
+}
+
+auto truncate_to_millisecond(FrameTime const& ft) noexcept -> FrameTime
+{
+    auto const in_ms = ft.value() / kNsPerMs;
+    return FrameTime { in_ms * kNsPerMs };
+}
+auto from_fps(std::uint32_t fps) noexcept -> FrameTime
+{
+    return FrameTime { kNsPerSec / fps };
+}
+
+} // namespace sc

--- a/src/utils/frame_time.hpp
+++ b/src/utils/frame_time.hpp
@@ -1,0 +1,26 @@
+#ifndef SHADOW_CAST_UTILS_FRAME_TIME_HPP_INCLUDED
+#define SHADOW_CAST_UTILS_FRAME_TIME_HPP_INCLUDED
+
+#include <cstdint>
+#include <libavutil/rational.h>
+
+namespace sc
+{
+struct FrameTime
+{
+    explicit FrameTime(std::uint64_t) noexcept;
+    auto value() const noexcept -> std::uint64_t;
+    auto value_in_milliseconds() const noexcept -> std::uint64_t;
+    auto fps() const noexcept -> float;
+    auto per_second_ratio() const noexcept -> AVRational;
+
+private:
+    std::uint64_t frame_time_nanoseconds_;
+};
+
+auto truncate_to_millisecond(FrameTime const&) noexcept -> FrameTime;
+auto from_fps(std::uint32_t) noexcept -> FrameTime;
+
+} // namespace sc
+
+#endif // SHADOW_CAST_UTILS_FRAME_TIME_HPP_INCLUDED

--- a/tools/make-dist
+++ b/tools/make-dist
@@ -14,6 +14,7 @@ mkdir ./dist
 tar \
     --exclude './build' \
     --exclude './dist' \
+    --exclude './report' \
     --exclude './.private' \
     --exclude './.git' \
     --exclude './.github' \

--- a/tools/metrics/average
+++ b/tools/metrics/average
@@ -5,18 +5,26 @@ usage() {
 Usage ${0} [ OPTION... ] <INPUT FILE>
 OPTIONS
   -a    Audio
+  -A    Audio encoder
   -v    Video (default)
+  -V    Video encoder
 EOF
 }
 
 category=1
-while getopts 'av' opt; do
+while getopts 'aAvV' opt; do
     case "${opt}" in
         a)
             category=2
             ;;
+        A)
+            category=4
+            ;;
         v)
             category=1
+            ;;
+        V)
+            category=3
             ;;
         ?)
             usage

--- a/tools/metrics/percentile
+++ b/tools/metrics/percentile
@@ -5,18 +5,26 @@ usage() {
 Usage ${0} [ OPTION... ] <INPUT FILE> <PERCENTILE>
 OPTIONS
   -a    Audio
+  -A    Audio Encoding
   -v    Video (default)
+  -V    Video Encoding
 EOF
 }
 
 category=1
-while getopts 'av' opt; do
+while getopts 'aAvV' opt; do
     case "${opt}" in
         a)
             category=2
             ;;
         v)
             category=1
+            ;;
+        A)
+            category=4
+            ;;
+        V)
+            category=3
             ;;
         ?)
             usage
@@ -32,7 +40,7 @@ if [[ $# -lt 2 ]]; then
     exit 1
 fi
 
-set -x
+#set -x
 
 <"${1}" grep -E '^'${category}'' \
     | sort -k4 -t, -g \

--- a/tools/metrics/plot
+++ b/tools/metrics/plot
@@ -2,11 +2,17 @@
 
 exclude_audio=0
 exclude_video=0
+video_category=1
+audio_category=2
 
-while getopts 'sVA' opt; do
+while getopts 'sVAe' opt; do
     case "${opt}" in
         A)
             exclude_audio=1
+            ;;
+        e)
+            video_category=3
+            audio_category=4
             ;;
         s)
             smoothval='smooth csplines'
@@ -32,6 +38,7 @@ if [[ ${exclude_audio} -ne 0 ]] && [[ ${exclude_audio} == ${exclude_video} ]]; t
 fi
 
 inputfile="${1}"
+yrange="4"
 
 set -x
 #
@@ -46,14 +53,14 @@ set xdata time
 set xlabel "Time (seconds)"
 set ylabel "Frame Time (milliseconds)"
 set xtics 30
-set yrange [0:16]
+set yrange [0:${yrange}]
 
-$([[ ${exclude_audio} -eq 1 ]] && echo "plot '< grep -E \"^1\" "${inputfile}" | cut -d, -f3,4' \
+$([[ ${exclude_audio} -eq 1 ]] && echo "plot '< grep -E \"^${video_category}\" "${inputfile}" | cut -d, -f3,4' \
  using (\$1/1000000000):(\$2/1000000) ${smoothval} with lines title \"Video\"")
-$([[ ${exclude_video} -eq 1 ]] && echo "plot '< grep -E \"^2\" "${inputfile}" | cut -d, -f3,4' \
+$([[ ${exclude_video} -eq 1 ]] && echo "plot '< grep -E \"^${audio_category}\" "${inputfile}" | cut -d, -f3,4' \
  using (\$1/1000000000):(\$2/1000000) ${smoothval} with lines title \"Audio\"")
-$([[ ${exclude_audio} -eq ${exclude_video} ]] && echo "plot '< grep -E \"^1\" "${inputfile}" | cut -d, -f3,4' \
+$([[ ${exclude_audio} -eq ${exclude_video} ]] && echo "plot '< grep -E \"^${video_category}\" "${inputfile}" | cut -d, -f3,4' \
  using (\$1/1000000000):(\$2/1000000) ${smoothval} with lines title \"Video\", \
- '< grep -E \"^2\" "${inputfile}" | cut -d, -f3,4' \
+ '< grep -E \"^${audio_category}\" "${inputfile}" | cut -d, -f3,4' \
  using (\$1/1000000000):(\$2/1000000) ${smoothval} with lines title \"Audio\"")
 EOF

--- a/tools/next-version
+++ b/tools/next-version
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+project_dir=$(cd $(dirname ${0})/..; pwd)
+changes_dir="${project_dir}/.versioning/changes"
+current_version=$(cat ${project_dir}/.versioning/current | tr -d '\n')
+
+version_list=(${current_version})
+
+test_multiple() {
+    [[ $(ls -1 "${changes_dir}" 2>/dev/null | grep "${1}" | wc -l) -gt 0 ]]
+}
+
+if test_multiple "patch" ; then
+    version_list+=($(echo "${current_version}" | semverutil -P))
+fi
+
+if test_multiple "minor" ; then
+    version_list+=($(echo "${current_version}" | semverutil -N))
+fi
+
+if test_multiple "major" ; then
+    version_list+=($(echo "${current_version}" | semverutil -M))
+fi
+
+echo ${version_list[@]} | semverutil

--- a/tools/performance-report
+++ b/tools/performance-report
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+print_usage() {
+    cat >&2 <<-EOF
+USAGE ${0} <CAPTURE_MEDIA_FILE> <PLATFORM>
+EOF
+}
+
+[[ $# -eq 2 ]] || {
+    echo "Incorrect number of arguments" >&2
+    print_usage
+    exit 1
+}
+
+metrics_file="${1}.metrics"
+platform="${2}"
+
+[[ -f "${metrics_file}" ]] || {
+    echo "Couldn't find metrics file: ${metrics_file}" >&2
+    exit 1
+}
+
+this_dir=$(cd $(dirname "${0}"); pwd)
+report_dir="$(cd "${this_dir}/.."; pwd)/report"
+percentile="${this_dir}/metrics/percentile"
+average="${this_dir}/metrics/average"
+plot="${this_dir}/metrics/plot"
+
+[[ -d "${report_dir}" ]] && rm -rf "${report_dir}"
+mkdir -p "${report_dir}/images"
+
+print_percentiles() {
+    echo "| Percentile  | Video     | Audio     | Video encoding | Audio encoding |"
+    echo "|----------   |---------  |--------   |--------------- |--------------- |"
+    for p in "99.99" 99 90 75 50; do
+        local video_val=$(printf "%.3fms" $(${percentile} -v "${metrics_file}" ${p} | awk -F, '{ print $4/1000000; }'))
+        local video_encoding_val=$(printf "%.3fms" $(${percentile} -V "${metrics_file}" ${p} | awk -F, '{ print $4/1000000; }'))
+        local audio_val=$(printf "%.3fms" $(${percentile} -a "${metrics_file}" ${p} | awk -F, '{ print $4/1000000; }'))
+        local audio_encoding_val=$(printf "%.3fms" $(${percentile} -A "${metrics_file}" ${p} | awk -F, '{ print $4/1000000; }'))
+        echo "| ${p}        | \`${video_val}\`  | \`${audio_val}\`  | \`${video_encoding_val}\` | \`${audio_encoding_val}\` |"
+    done
+}
+
+print_averages() {
+    echo "| Stream  | Capture       | Encoding  |"
+    echo "|-------- |-------------  |---------  |"
+
+    local video_val=$(${average} -v "${metrics_file}")
+    local video_encoding_val=$(${average} -V "${metrics_file}")
+    local audio_val=$(${average} -a "${metrics_file}")
+    local audio_encoding_val=$(${average} -A "${metrics_file}")
+
+    echo "| Video   | \`$(printf "%.3fms" $(echo "scale=3; ${video_val}/1000000" | bc))\`  | \
+        \`$(printf "%.3fms" $(echo "scale=3; ${video_encoding_val}/1000000" | bc))\`  |"
+    echo "| Audio   | \`$(printf "%.3fms" $(echo "scale=3; ${audio_val}/1000000" | bc))\`  | \
+        \`$(printf "%.3fms" $(echo "scale=3; ${audio_encoding_val}/1000000" | bc))\`  |"
+}
+
+generate_charts() {
+    ${plot} -A ${metrics_file} 2>/dev/null
+    cp ${metrics_file}.chart.png "${report_dir}/images/${platform}-video-detailed.png"
+    echo "##### Video frame times"
+    echo -e "![Video frame times](images/${platform}-video-detailed.png)\n"
+    ${plot} -e -A ${metrics_file} 2>/dev/null
+    cp ${metrics_file}.chart.png "${report_dir}/images/${platform}-video-encoding-detailed.png"
+    echo "##### Video encoding frame times"
+    echo -e "![Video encoding frame times](images/${platform}-video-encoding-detailed.png)\n"
+    ${plot} -V ${metrics_file} 2>/dev/null
+    cp ${metrics_file}.chart.png "${report_dir}/images/${platform}-audio-detailed.png"
+    echo "##### Audio frame times"
+    echo -e "![Audio frame times](images/${platform}-audio-detailed.png)\n"
+    ${plot} -e -V ${metrics_file} 2>/dev/null
+    cp ${metrics_file}.chart.png "${report_dir}/images/${platform}-audio-encoding-detailed.png"
+    echo "##### Audio encoding frame times"
+    echo -e "![Audio encoding frame times](images/${platform}-audio-encoding-detailed.png)\n"
+    ${plot} -s ${metrics_file} 2>/dev/null
+    cp ${metrics_file}.chart.png "${report_dir}/images/${platform}-video-audio-downsampled.png"
+    echo "##### Video and Audio frame times (downsampled)"
+    echo -e "![Video and Audio frame times downsampled](images/${platform}-video-audio-downsampled.png)\n"
+    ${plot} -e -s ${metrics_file} 2>/dev/null
+    cp ${metrics_file}.chart.png "${report_dir}/images/${platform}-video-audio-encoding-downsampled.png"
+    echo "##### Video and Audio encoding frame times (downsampled)"
+    echo -e "![Video and Audio encoding frame times downsampled](images/${platform}-video-audio-encoding-downsampled.png)\n"
+}
+
+(
+echo -e "### Performance - ${platform}"
+echo -e "Version: \`$(${this_dir}/next-version | tr -d '\n')\`\n"
+echo -e "#### Average frame times\n"
+print_averages
+echo -e "\n#### Frame time percentiles\n"
+print_percentiles
+echo -e "\n#### Frame time charts\n"
+generate_charts
+) | tee "${report_dir}/${platform}-report.md"
+
+markdown "${report_dir}/${platform}-report.md" > "${report_dir}/${platform}-report.html"


### PR DESCRIPTION
Performance:
- Adds dedicated thread for dequeueing and writing encoded packets
- Use native (BGRA) colourspace for NVFBC capture Using the native colourspace means NVFBC doesn't have to perform any conversion. In theory, this will improve capture performance
- Allow NvFBC to wait up to a maximum time for a new frame

Fixes:
- Adds eventfd for cancelling contexts without timers Contexts without timers require this to be cancellable with `request_stop()`.
- Fixes memory leak in h/w frame context initialization

Other:
- Adds metrics for video and audio encoding frame times
- Adds performance report generator script
- Allows NvFBC adjusted FPS to be enabled/disabled with ENV var `SHADOW_CAST_STRICT_FPS`. Defaults to `1`.
- Add FAQ