### PR TITLE
fix: Typo in FFMpeg find module

### DIFF
--- a/.versioning/changes/tDzfsWLvKj.patch.md
+++ b/.versioning/changes/tDzfsWLvKj.patch.md
@@ -1,0 +1,1 @@
+Fixes an issue where builds would fail if the FFMpeg headers are located under a subfolder within `/usr/include` (thanks: @SleepingPanda)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ In order to build *Shadow Cast* you will need a C++20 compiler, plus the followi
 - ffmpeg / libav
 - X11
 - Pipewire
-- Wayland (wayland-client, wayland-egl)
+- Wayland (wayland-client, wayland-egl, wayland-devel)
 - libdrm
+- libglvnd
 
 These can usually be obtained through your Linux distribution's package manager using the `-devel` packages of each.
 

--- a/cmake/FindFFMpeg.cmake
+++ b/cmake/FindFFMpeg.cmake
@@ -11,7 +11,7 @@ function(try_find_ffmpeg_targets)
     )
 
     foreach(FFMPEG_COMPONENT ${EXPORT_FFMPEG_NAMES})
-        pkg_check_modules(PC_${FFMPEG_COMPONENT}_CODEC QUIET "lib${FFMPEG_COMPONENT}")
+        pkg_check_modules(PC_${FFMPEG_COMPONENT} QUIET "lib${FFMPEG_COMPONENT}")
 
         find_path(FFMpeg_${FFMPEG_COMPONENT}_INCLUDE_DIR
             NAMES ${FFMPEG_COMPONENT}.h


### PR DESCRIPTION
This fixes build failures on systems where the FFMpeg headers are located under an additional subfolder within `/usr/include`.

Fixes #34