### PR TITLE
fix: Look for DRM helper in the main executable's directory

### DIFF
--- a/.versioning/changes/1Y73bS2GJt.patch.md
+++ b/.versioning/changes/1Y73bS2GJt.patch.md
@@ -1,0 +1,1 @@
+Users now are now no longer required to have the `shadow-cast-kms` executable in their `$PATH` if installed to a custom location. The process will look for it in the same location as the main `shadow-cast` executable.


### PR DESCRIPTION
The process will now look for `shadow-cast-kms` in the same directory as the main `shadow-cast` binary.

This makes us more portable when it comes to the installation location. Previously, the user had to ensure that `shadow-cast-kms` was in their `$PATH` if they installed to a custom location.