### PR TITLE
fix: Removes unreliable DRM availability check

### DIFF
--- a/.versioning/changes/KlqMy7e94g.patch.md
+++ b/.versioning/changes/KlqMy7e94g.patch.md
@@ -1,0 +1,1 @@
+Fixes an issue where a DRM driver can be incorretly reported as unavailable in Wayland (thanks: @SleepingPanda).

--- a/src/kms.cpp
+++ b/src/kms.cpp
@@ -52,8 +52,6 @@ decltype(auto) log()
     }
 }
 
-[[nodiscard]] auto is_drm_available() -> bool { return drmAvailable() == 1; }
-
 [[nodiscard]] auto get_drm_device_path() -> std::string
 {
     int const max_devices = 10;
@@ -306,9 +304,6 @@ auto get_plane_descriptors(int drm_fd) -> OutgoingMessage
 auto app(std::span<char const*> args) -> void
 {
     sc::block_signals({ SIGINT });
-
-    if (!is_drm_available())
-        throw std::runtime_error { "DRM not available" };
 
     auto const device_path = get_drm_device_path();
 


### PR DESCRIPTION
The `drmAvailable()` function is seemingly returning false negatives in some scenarios. A reported example of this was KDE Plasma where the GPU was on `/dev/dri/card1`. The DRM planes were available even though this check failed. Seems we can just remove the check altogether.