### PR TITLE
fix: Revert to using FPS as the video encoding timebase

### DIFF
--- a/.versioning/changes/ABD4J08NAE.patch.md
+++ b/.versioning/changes/ABD4J08NAE.patch.md
@@ -1,0 +1,1 @@
+Reverts to using FPS as the video encoding timebase. This avoids some surprising behaviour with nvenc

--- a/src/av/codec.cpp
+++ b/src/av/codec.cpp
@@ -30,7 +30,7 @@ auto create_video_encoder(std::string const& encoder_name,
     sc::CodecContextPtr video_encoder_context { avcodec_alloc_context3(
         video_encoder.get()) };
     video_encoder_context->codec_id = video_encoder->id;
-    auto const timebase = ft.per_second_ratio();
+    auto const timebase = ft.fps_ratio();
     video_encoder_context->time_base = timebase;
     video_encoder_context->framerate.num = timebase.den;
     video_encoder_context->framerate.den = timebase.num;

--- a/src/handlers/drm_video_frame_writer.cpp
+++ b/src/handlers/drm_video_frame_writer.cpp
@@ -16,7 +16,7 @@ DRMVideoFrameWriter::DRMVideoFrameWriter(AVCodecContext* codec_context,
 
 auto DRMVideoFrameWriter::operator()(CUarray data,
                                      NvCuda const& cuda,
-                                     std::uint64_t frame_time) -> void
+                                     std::uint64_t /*frame_time*/) -> void
 {
     SC_EXPECT(data);
 
@@ -64,7 +64,7 @@ auto DRMVideoFrameWriter::operator()(CUarray data,
         };
     }
 
-    frame->pts = frame_time * frame_number_++;
+    frame->pts = frame_number_++;
 
     encoder_.write_frame(std::move(encoder_frame));
 }

--- a/src/handlers/video_frame_writer.cpp
+++ b/src/handlers/video_frame_writer.cpp
@@ -17,7 +17,7 @@ VideoFrameWriter::VideoFrameWriter(AVCodecContext* codec_context,
 
 auto VideoFrameWriter::operator()(CUdeviceptr cu_device_ptr,
                                   NVFBC_FRAME_GRAB_INFO,
-                                  std::uint64_t frame_time) -> void
+                                  std::uint64_t /*frame_time*/) -> void
 {
     auto encoder_frame =
         encoder_.prepare_frame(codec_context_.get(), stream_.get());
@@ -42,7 +42,7 @@ auto VideoFrameWriter::operator()(CUdeviceptr cu_device_ptr,
     frame->colorspace = codec_context_->colorspace;
     frame->chroma_location = codec_context_->chroma_sample_location;
 
-    frame->pts = frame_time * frame_number_++;
+    frame->pts = frame_number_++;
 
     encoder_.write_frame(std::move(encoder_frame));
 }

--- a/src/utils/frame_time.cpp
+++ b/src/utils/frame_time.cpp
@@ -31,9 +31,9 @@ auto FrameTime::fps() const noexcept -> float
     return static_cast<float>(kNsPerSec) / frame_time_nanoseconds_;
 }
 
-auto FrameTime::per_second_ratio() const noexcept -> AVRational
+auto FrameTime::fps_ratio() const noexcept -> AVRational
 {
-    return AVRational { .num = 1, .den = kNsPerSec };
+    return av_make_q(1, static_cast<int>(fps()));
 }
 
 auto truncate_to_millisecond(FrameTime const& ft) noexcept -> FrameTime

--- a/src/utils/frame_time.hpp
+++ b/src/utils/frame_time.hpp
@@ -12,7 +12,7 @@ struct FrameTime
     auto value() const noexcept -> std::uint64_t;
     auto value_in_milliseconds() const noexcept -> std::uint64_t;
     auto fps() const noexcept -> float;
-    auto per_second_ratio() const noexcept -> AVRational;
+    auto fps_ratio() const noexcept -> AVRational;
 
 private:
     std::uint64_t frame_time_nanoseconds_;


### PR DESCRIPTION
The ffmpeg-to-nvenc encoding behaves strangley if the timebase isn't in FPS. It doesn't seem to respect CBR encoding, among other things.