### PR TITLE
fix: A/V desync' when using opus audio encoder

### DIFF
--- a/.versioning/changes/nBpZUnmkTX.patch.md
+++ b/.versioning/changes/nBpZUnmkTX.patch.md
@@ -1,0 +1,1 @@
+Fixes an A/V desync issue with the opus encoder

--- a/src/av/sample_format.cpp
+++ b/src/av/sample_format.cpp
@@ -46,4 +46,36 @@ auto is_sample_rate_supported(std::uint32_t requested,
     return false;
 }
 
+auto sample_format_name(SampleFormat fmt) noexcept -> char const*
+{
+    switch (fmt) {
+    case SampleFormat::u8_interleaved:
+        return "u8_interleaved";
+    case SampleFormat::s16_interleaved:
+        return "s16_interleaved";
+    case SampleFormat::s32_interleaved:
+        return "s32_interleaved";
+    case SampleFormat::float_interleaved:
+        return "float_interleaved";
+    case SampleFormat::double_interleaved:
+        return "double_interleaved";
+    case SampleFormat::u8_planar:
+        return "u8_planar";
+    case SampleFormat::s16_planar:
+        return "s16_planar";
+    case SampleFormat::s32_planar:
+        return "s32_planar";
+    case SampleFormat::float_planar:
+        return "float_planar";
+    case SampleFormat::double_planar:
+        return "double_planar";
+    case SampleFormat::s64_interleaved:
+        return "s64_interleaved";
+    case SampleFormat::s64_planar:
+        return "s64_planar";
+    default:
+        return "unknown";
+    }
+}
+
 } // namespace sc

--- a/src/av/sample_format.hpp
+++ b/src/av/sample_format.hpp
@@ -182,6 +182,8 @@ auto constexpr convert_to_pipewire_format(SampleFormat fmt) -> spa_audio_format
     throw std::runtime_error { "No viable Pipewire sample format conversion " };
 }
 
+auto sample_format_name(SampleFormat fmt) noexcept -> char const*;
+
 auto find_supported_formats(sc::BorrowedPtr<AVCodec const> codec)
     -> std::vector<SampleFormat>;
 

--- a/src/handlers/audio_chunk_writer.hpp
+++ b/src/handlers/audio_chunk_writer.hpp
@@ -12,7 +12,8 @@ struct ChunkWriter
 {
     explicit ChunkWriter(AVCodecContext* codec_context,
                          AVStream* stream,
-                         Encoder encoder) noexcept;
+                         Encoder encoder,
+                         std::size_t frame_size) noexcept;
 
     auto operator()(MediaChunk const& chunk) -> void;
 
@@ -20,6 +21,7 @@ private:
     BorrowedPtr<AVCodecContext> codec_context_;
     BorrowedPtr<AVStream> stream_;
     Encoder encoder_;
+    std::size_t frame_size_;
     FramePtr frame_;
     std::size_t total_samples_written_ { 0 };
 };

--- a/tests/histogram_tests.cpp
+++ b/tests/histogram_tests.cpp
@@ -89,8 +89,6 @@ auto should_print_histogram() -> void
 
     sc::metrics::format_histogram(
         std::cerr, histogram, "Frame-time Nanoseconds", "Test Histogram");
-
-    EXPECT(false);
 }
 
 auto main() -> int


### PR DESCRIPTION
Uses an `eventfd` to notify when Pipewire has filled a complete frame of audio data. This reduces the amount of copying and lock contention when processing audio buffers.