### PR TITLE
fix(#14) Renders cursor on Wayland captures

### DIFF
--- a/.versioning/changes/DgYJuQAr9O.patch.md
+++ b/.versioning/changes/DgYJuQAr9O.patch.md
@@ -1,0 +1,1 @@
+The mouse cursor is now captured on Wayland (fixes #14)

--- a/src/av/codec.cpp
+++ b/src/av/codec.cpp
@@ -3,6 +3,7 @@
 #include "error.hpp"
 #include "nvidia.hpp"
 #include <X11/Xlib.h>
+#include <libavutil/rational.h>
 extern "C" {
 #include <libavutil/hwcontext_cuda.h>
 }
@@ -34,8 +35,7 @@ auto create_video_encoder(std::string const& encoder_name,
     video_encoder_context->time_base = timebase;
     video_encoder_context->framerate.num = timebase.den;
     video_encoder_context->framerate.den = timebase.num;
-    video_encoder_context->sample_aspect_ratio.num = 0;
-    video_encoder_context->sample_aspect_ratio.den = 0;
+    video_encoder_context->sample_aspect_ratio = AVRational { 1, 1 };
     video_encoder_context->max_b_frames = 0;
     video_encoder_context->pix_fmt = AV_PIX_FMT_CUDA;
     video_encoder_context->bit_rate = 100'000;

--- a/src/gl/core.cpp
+++ b/src/gl/core.cpp
@@ -23,4 +23,16 @@ auto clear_color(float red, float green, float blue, float alpha) noexcept
     gl().glClearColor(red, green, blue, alpha);
 }
 
+auto enable(GLenum cap) -> void
+{
+    gl().glEnable(cap);
+    SC_CHECK_GL_ERROR("glEnable");
+}
+
+auto blend_function(GLenum sfactor, GLenum dfactor) -> void
+{
+    gl().glBlendFunc(sfactor, dfactor);
+    SC_CHECK_GL_ERROR("glBlendFunc");
+}
+
 } // namespace sc::opengl

--- a/src/gl/core.hpp
+++ b/src/gl/core.hpp
@@ -10,6 +10,9 @@ auto clear(GLenum mask) -> void;
 auto clear_color(float red, float green, float blue, float alpha) noexcept
     -> void;
 
+auto enable(GLenum cap) -> void;
+auto blend_function(GLenum sfactor, GLenum dfactor) -> void;
+
 } // namespace sc::opengl
 
 #endif // SHADOW_CAST_GL_CORE_HPP_INCLUDED

--- a/src/gl/texture.cpp
+++ b/src/gl/texture.cpp
@@ -3,14 +3,15 @@
 #include "platform/opengl.hpp"
 #include "utils/contracts.hpp"
 #include <GL/gl.h>
+#include <cstdio>
 
 namespace sc::opengl
 {
 
-auto TextureTraits::bind(GLenum target, GLuint name) const -> void
+auto TextureTraits::bind(GLenum target, GLuint name) const noexcept -> void
 {
     gl().glBindTexture(target, name);
-    SC_CHECK_GL_ERROR("glBindTexture");
+    SC_CHECK_GL_ERROR_NOEXCEPT("glBindTexture");
 }
 
 auto TextureTraits::create() const -> GLuint
@@ -24,7 +25,7 @@ auto TextureTraits::create() const -> GLuint
 auto TextureTraits::destroy(GLuint name) const noexcept -> void
 {
     gl().glDeleteTextures(1, &name);
-    SC_CHECK_GL_ERROR("glDeleteTextures");
+    SC_CHECK_GL_ERROR_NOEXCEPT("glDeleteTextures");
 }
 
 } // namespace sc::opengl

--- a/src/gl/texture.hpp
+++ b/src/gl/texture.hpp
@@ -30,7 +30,7 @@ struct TextureTraits
 {
     using category = TextureCategory;
 
-    auto bind(GLenum target, GLuint name) const -> void;
+    auto bind(GLenum target, GLuint name) const noexcept -> void;
     auto create() const -> GLuint;
     auto destroy(GLuint name) const noexcept -> void;
 };

--- a/src/glsl/CMakeLists.txt
+++ b/src/glsl/CMakeLists.txt
@@ -5,4 +5,6 @@ add_embedded_glsl_target(
     SOURCES
         default_vertex.glsl
         default_fragment.glsl
+        mouse_vertex.glsl
+        mouse_fragment.glsl
 )

--- a/src/glsl/mouse_fragment.glsl
+++ b/src/glsl/mouse_fragment.glsl
@@ -7,7 +7,7 @@ uniform samplerExternalOES texture_sampler;
 
 void main()
 {
-    FragColor = vec4(texture2D(texture_sampler, tex_coord).rgb, 1.0);
+    FragColor = texture2D(texture_sampler, tex_coord);
 }
 
 // vim: ft=glsl

--- a/src/glsl/mouse_vertex.glsl
+++ b/src/glsl/mouse_vertex.glsl
@@ -1,0 +1,52 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec2 aTexCoord;
+
+uniform vec2 screen_dimensions;
+uniform vec2 mouse_dimensions;
+uniform vec2 mouse_position;
+
+out vec2 tex_coord;
+
+void main()
+{
+    /* NOTE:
+     *  We must scale all the mouse plane's dimensions and screen position
+     * to -1.0,1.0 coords...
+     * - First scale the mouse plane to the screen scale.
+     * - Then offset the mouse position by _adding_ half its w/h,
+     *   and _subtracting_ half the screen w/h.
+     * - Finally translate its x/y position by dividing by half screen
+     *   w/h.
+     */
+
+    /* NOTE:
+     *  We don't have to worry about inverting the y coords because the
+     * texture will render upside down (which is correct when we finally
+     * copy it to the encoder stage).
+     */
+
+    vec2 scaled_dimensions = mouse_dimensions / screen_dimensions;
+    mat4 scale;
+    scale[0] = vec4(scaled_dimensions.x, 0.0, 0.0, 0.0);
+    scale[1] = vec4(0.0, scaled_dimensions.y, 0.0, 0.0);
+    scale[2] = vec4(0.0, 0.0, 1.0, 0.0);
+    scale[3] = vec4(0.0, 0.0, 0.0, 1.0);
+
+    vec2 half_screen = screen_dimensions / 2;
+
+    vec2 mpos = (mouse_position + mouse_dimensions / 2) - half_screen;
+
+    mat4 translate;
+    translate[0] = vec4(1.0, 0.0, 0.0, 0.0);
+    translate[1] = vec4(0.0, 1.0, 0.0, 0.0);
+    translate[2] = vec4(0.0, 0.0, 1.0, 0.0);
+    translate[3] = vec4(mpos / half_screen, 0.0, 1.0);
+
+    mat4 mv = translate * scale;
+
+    gl_Position = mv * vec4(aPos, 1.0);
+    tex_coord = aTexCoord;
+}
+
+// vim: ft=glsl

--- a/src/platform/opengl.cpp
+++ b/src/platform/opengl.cpp
@@ -80,6 +80,8 @@ auto load_opengl() -> OpenGL
     TRY_ATTACH_SYMBOL(&opengl.glUniform2fv, "glUniform2fv", lib);
     TRY_ATTACH_SYMBOL(&opengl.glUniform3fv, "glUniform3fv", lib);
     TRY_ATTACH_SYMBOL(&opengl.glUniform4fv, "glUniform4fv", lib);
+    TRY_ATTACH_SYMBOL(&opengl.glEnable, "glEnable", lib);
+    TRY_ATTACH_SYMBOL(&opengl.glBlendFunc, "glBlendFunc", lib);
 
     return opengl;
 }

--- a/src/platform/opengl.hpp
+++ b/src/platform/opengl.hpp
@@ -123,6 +123,8 @@ struct OpenGL
     void (*glUniform2fv)(GLint location, GLsizei count, const GLfloat* value);
     void (*glUniform3fv)(GLint location, GLsizei count, const GLfloat* value);
     void (*glUniform4fv)(GLint location, GLsizei count, const GLfloat* value);
+    void (*glEnable)(GLenum cap);
+    void (*glBlendFunc)(GLenum sfactor, GLenum dfactor);
 
     /* NOTE:
      *  Extensions...

--- a/src/services/color_converter.hpp
+++ b/src/services/color_converter.hpp
@@ -7,9 +7,16 @@
 #include "gl/texture.hpp"
 #include "gl/vertex_array_object.hpp"
 #include <cstdint>
+#include <optional>
 
 namespace sc
 {
+
+struct MouseParameters
+{
+    std::uint32_t width, height;
+    std::int32_t x, y;
+};
 
 struct ColorConverter
 {
@@ -18,20 +25,25 @@ struct ColorConverter
 
     auto initialize() -> void;
     [[nodiscard]] auto input_texture() noexcept -> opengl::Texture&;
+    [[nodiscard]] auto mouse_texture() noexcept -> opengl::Texture&;
     [[nodiscard]] auto output_texture() noexcept -> opengl::Texture&;
-    auto convert() -> void;
+    auto convert(std::optional<MouseParameters> mouse_params) -> void;
 
 private:
     opengl::Framebuffer fbo_;
     opengl::Texture input_texture_;
+    opengl::Texture mouse_texture_;
     opengl::Texture output_texture_;
     opengl::VertexArray vao_;
     opengl::Buffer vertex_buffer_;
     opengl::Buffer texture_coords_buffer_;
     opengl::Buffer index_buffer_;
     opengl::Program program_;
+    opengl::Program mouse_program_;
     std::uint32_t output_width_;
     std::uint32_t output_height_;
+    GLuint mouse_dimensions_uniform_;
+    GLuint mouse_position_uniform_;
     bool initialized_ { false };
 };
 


### PR DESCRIPTION
This change introduces a second shader pass to render the cursor plane on Wayland.

fixes #14